### PR TITLE
Removed comma from parameters

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -44,7 +44,7 @@ Puppet::Type.newtype(:firewalld_zone) do
         :name     => purge,
         :raw_rule => purge,
         :ensure   => :absent,
-        :zone     => self[:name],
+        :zone     => self[:name]
       )
     end
     return purge_rules


### PR DESCRIPTION
In our environment, catalog compilation failed with the following error:
Could not retrieve catalog from remote server: Error 400 on SERVER: Could not autoload puppet/type/firewalld_zone: /etc/puppet/environments/lab/modules/firewalld/lib/puppet/type/firewalld_zone.rb:47: syntax error, unexpected ')'
/etc/puppet/environments/lab/modules/firewalld/lib/puppet/type/firewalld_zone.rb:53: syntax error, unexpected $end, expecting kEND on node

Removing the extra comma from this list solved our problem.