### PR TITLE
New support for services and icmp blocks

### DIFF
--- a/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
@@ -1,0 +1,30 @@
+require 'puppet'
+
+Puppet::Type.type(:firewalld_custom_service).provide :firewall_cmd do
+  desc "Interact with firewall-cmd"
+
+
+  commands :firewall_cmd => 'firewall-cmd'
+
+
+  def exec_firewall(*extra_args)
+    args=[]
+    args << '--permanent'
+    args << extra_args
+    args.flatten!
+    firewall_cmd(args)
+  end
+
+  def exists?
+    exec_firewall('--get-services').split(/ /).include?(@resource[:name])
+  end
+
+  def create
+    exec_firewall('--new-service', @resource[:name])
+  end
+
+  def destroy
+    exec_firewall('--delete-service', @resource[:name])
+  end
+
+end

--- a/lib/puppet/provider/firewalld_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_service/firewall_cmd.rb
@@ -1,0 +1,34 @@
+require 'puppet'
+
+Puppet::Type.type(:firewalld_service).provide :firewall_cmd do
+  desc "Interact with firewall-cmd"
+
+
+  commands :firewall_cmd => 'firewall-cmd'
+
+  # First arg should be the zone name
+  def exec_firewall(*extra_args)
+    args=[]
+    args << '--permanent'
+    args << '--zone'
+    args << @resource[:zone]
+    args << extra_args
+    args.flatten!
+    firewall_cmd(args)
+  end
+
+  def exists?
+    exec_firewall('--list-services').split(" ").include?(@resource[:service])
+  end
+
+  def create
+    self.debug("Adding new service to firewalld: #{@resource[:service]}")
+    exec_firewall('--add-service', @resource[:service])
+  end
+
+  def destroy
+    self.debug("Removing service from firewalld: #{@resource[:service]}")
+    exec_firewall('--remove-service', @resource[:service])
+  end
+
+end

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -16,20 +16,22 @@ Puppet::Type.type(:firewalld_zone).provide :firewall_cmd do
   end
 
   def zone_exec_firewall(*extra_args)
-    args = [ '--zone', @resource[:name]]
+    args = [ "--zone=#{@resource[:name]}" ]
     exec_firewall(args, extra_args)
   end
 
   def exists?
-    exec_firewall('--get-zones').split(/ /).include?(@resource[:name])
+    exec_firewall('--get-zones').split(" ").include?(@resource[:name])
   end
 
   def create
+    self.debug("Creating new zone #{@resource[:name]}")
     exec_firewall('--new-zone', @resource[:name])
     self.target=(@resource[:target]) 
   end
 
   def destroy
+    self.debug("Deleting zone #{@resource[:name]}")
     exec_firewall('--delete-zone', @resource[:name])
   end
 
@@ -38,16 +40,90 @@ Puppet::Type.type(:firewalld_zone).provide :firewall_cmd do
   end
 
   def target=(t)
+    self.debug("Setting target for zone #{@resource[:name]} to #{@resource[:target]}")
     zone_exec_firewall('--set-target', @resource[:target])
   end
+  
+  def icmp_blocks
+    get_icmp_blocks()
+  end
 
-  ## TODO: Add ICM blocks, ports and other zone options
+  def icmp_blocks=(i)
+    set_blocks = Array.new
+    remove_blocks = Array.new
+    
+    case i
+    
+    when Array then
+    
+        get_icmp_blocks.each do |remove_block|
+                if !i.include?(remove_block)
+                    self.debug("removing block #{remove_block} from zone #{@resource[:name]}")
+                    remove_blocks.push(remove_block)
+                end
+        end
+    
+        i.each do |block|
+        
+            if block.is_a?(String)
+                if get_icmp_types().include?(block)
+                    self.debug("adding block #{block} to zone #{@resource[:name]}")
+                    set_blocks.push(block)
+                else
+                    valid_types = get_icmp_types().join(', ')
+                    raise Puppet::Error, "#{block} is not a valid icmp type on this system! Valid types are: #{valid_types}"
+                end
+            else
+                raise Puppet::Error, "parameter icmp_blocks must be a string or array of strings!"
+            end
+        end
+    when String then
+    
+        get_icmp_blocks.reject { |x| x == i }.each do |remove_block|
+            self.debug("removing block #{remove_block} from zone #{@resource[:name]}")
+            remove_blocks.push(remove_block)
+        end
+    
+        if get_icmp_types().include?(i)
+            self.debug("adding block #{i} to zone #{@resource[:name]}")
+            set_blocks.push(i)
+        else
+            valid_types = get_icmp_types().join(', ')
+            raise Puppet::Error, "#{i} is not a valid icmp type on this system! Valid types are: #{valid_types}"
+        end
+    else
+        raise Puppet::Error, "parameter icmp_blocks must be a string or array of strings!"
+    end
+    if !remove_blocks.empty?
+        remove_blocks.each do |block|
+            zone_exec_firewall('--remove-icmp-block', block)
+        end
+    end
+    if !set_blocks.empty?
+        set_blocks.each do |block|
+            zone_exec_firewall('--add-icmp-block', block)
+        end
+    end
+  end
+
+  ## TODO: Add Ports and other zone options
   #
 
   def get_rules
     zone_exec_firewall('--list-rich-rules').split(/\n/)
   end
-
+  
+  def get_services
+    zone_exec_firewall('--list-services').split(' ')
+  end
+  
+  def get_icmp_blocks
+    zone_exec_firewall('--list-icmp-blocks').split(' ').sort
+  end
+  
+  def get_icmp_types
+    exec_firewall('--get-icmptypes').split(' ')
+  end
 
 end
 

--- a/lib/puppet/type/firewalld_custom_service.rb
+++ b/lib/puppet/type/firewalld_custom_service.rb
@@ -1,0 +1,47 @@
+require 'puppet'
+
+Puppet::Type.newtype(:firewalld_custom_service) do
+
+   @doc =%q{Creates a custom service definition in firewalld. Firewalld will create a blank template for
+     the service, to be replaced by the firewalld::custom_service defined type.
+  
+    Example:
+    
+        firewalld_custom_service {'MyService':}
+  
+  }
+
+  ensurable
+
+  newparam(:name, :namevar => :true) do
+    desc "Name of the custom service resource in Puppet"
+  end
+
+# Left in in case we decide to handle the config file creation directly in ruby instead of the defined type
+#  newparam(:short, :namevar => :true) do
+#    defaultto :name
+#    desc "Short name of the firewalld service (the one displayed on the command line output of various commands)"
+#  end
+#  
+#  newparam(:description) do
+#    desc "(Optional) A short description of the service"
+#  end
+#  
+#  newparam(:port) do
+#    desc "(Optional) An array of hashes, where each hash defines a protocol and/or port associated with this service. Each hash requires both port and protocol keys, even if the value is an empty string. Specifying a port only works for TCP & UDP, otherwise leave it empty and the entire protocol will be allowed"
+#  end
+#  
+#  newparam(:module) do
+#    desc "(Optional) An array of strings specifying netfilter kernel helper modules associated with this service"
+#  end
+#  
+#  newparam(:destination) do
+#    desc "(Optional) A hash specifying the destination network as a network IP address (optional with /mask), or a plain IP address. Valid hash keys are 'ipv4' and 'ipv6', with values corresponding to the IP / mask associated with each of those protocols. The use of hostnames is possible but not recommended, because these will only be resolved at service activation and transmitted to the kernel."
+#  end
+#  
+#  newparam(:config_dir) do
+#    desc "(Optional) The location where the service definition XML files will be stored. Defaults to /etc/firewalld/services"
+#    defaultto '/etc/firewalld/services'
+#  end
+
+end

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -2,6 +2,22 @@ require 'puppet'
 
 Puppet::Type.newtype(:firewalld_rich_rule) do
 
+  @doc =%q{Manages firewalld rich rules.
+
+    firewalld_rich_rules will autorequire the firewalld_zone specified in the zone parameter so there is no need to add dependancies for this  
+
+    Example:
+    
+      firewalld_rich_rule { 'Accept SSH from barny':
+        ensure => present,
+        zone   => 'restricted',
+        source => '192.168.1.2/32',
+        service => 'ssh',
+        action  => 'accept',
+      }
+  
+  }
+
   ensurable
 
   newparam(:name) do
@@ -76,7 +92,7 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
   end
 
   newparam(:raw_rule) do
-    desc "Manage the entire rule as one string - this is used internally by firwalld_zone
+    desc "Manage the entire rule as one string - this is used internally by firwalld_zone to
           handle pruning of rules"
   end
 

--- a/lib/puppet/type/firewalld_service.rb
+++ b/lib/puppet/type/firewalld_service.rb
@@ -1,0 +1,36 @@
+require 'puppet'
+
+Puppet::Type.newtype(:firewalld_service) do
+
+  @doc =%q{Assigns a service to a specific firewalld zone.
+    firewalld_Service will autorequire the firewalld_zone specified in the zone parameter so there is no need to add dependancies for this
+  
+    Example:
+        
+        firewalld_service {'Allow SSH in the public Zone':
+            ensure  => 'present',
+            zone    => 'public',
+            service => 'ssh',
+        }
+  
+  }
+
+  ensurable
+  
+  newparam(:name, :namevar => :true) do
+    desc "Name of the service resource in Puppet"
+  end
+  
+  newparam(:service) do
+    desc "Name of the service to add"
+  end
+  
+  newparam(:zone) do
+    desc "Name of the zone to which you want to add the service"
+  end
+  
+  autorequire(:firewalld_zone) do
+    self[:zone]
+  end
+
+end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -1,15 +1,42 @@
 require 'puppet'
+require 'puppet/parameter/boolean'
 require File.dirname(__FILE__).concat('/firewalld_rich_rule.rb')
+require File.dirname(__FILE__).concat('/firewalld_service.rb')
 
 Puppet::Type.newtype(:firewalld_zone) do
+
+  @doc =%q{Creates and manages firewald zones.
+    Note that setting ensure => 'absent' to the built in firewalld zones will
+    not work, and will generate an error. This is a limitation of firewalld itself, not the module.
+
+    Example:
+
+      firewalld_zone { 'restricted':
+        ensure           => present,
+        target           => '%%REJECT%%',
+        purge_rich_rules => true,
+        purge_services   => true,
+        icmp_blocks      => 'router-advertisement'
+      }
+
+  }
 
   ensurable
   
 
   def generate
-    if self[:purge_rich_rules] == :true
-      return purge_rich_rules
+  
+    resources = Array.new
+  
+    if self.purge_rich_rules?
+      resources.concat(purge_rich_rules())
     end
+    if self.purge_services?
+      resources.concat(purge_services())
+    end
+    
+    return resources
+    
   end
 
   newparam(:name) do
@@ -23,23 +50,44 @@ Puppet::Type.newtype(:firewalld_zone) do
   newproperty(:target) do
     desc "Specify the target for the zone"
   end
+  
+  newproperty(:icmp_blocks, :array_matching => :all) do
+    desc "Specify the icmp-blocks for the zone. Can be a single string specifying one icmp type,
+          or an array of strings specifying multiple icmp types. Any blocks not specified here will be removed
+         "
+    def insync?(is)
+        case should
+            when String then should.lines.sort == is
+            when Array then should.sort == is
+            else raise Puppet::Error, "parameter icmp_blocks must be a string or array of strings!"
+        end
+    end
+  end
 
-  newparam(:purge_rich_rules) do
+  newparam(:purge_rich_rules, :boolean => true, :parent => Puppet::Parameter::Boolean) do
     desc "When set to true any rich_rules associated with this zone
           that are not managed by Puppet will be removed.
          "
     defaultto :false
-    newvalues(:true, :false)
+  end
+  
+  newparam(:purge_services, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "When set to true any services associated with this zone
+          that are not managed by Puppet will be removed.
+         "
+    defaultto :false
   end
 
   def purge_rich_rules
-    return unless provider.exists?
-    purge_rules = []
-    puppet_rules = []
+    return Array.new unless provider.exists?
+    purge_rules = Array.new
+    puppet_rules = Array.new
     catalog.resources.select { |r| r.is_a?(Puppet::Type::Firewalld_rich_rule) }.each do |fwr|
+      self.debug("not purging puppet controlled rich rule #{fwr[:name]}")
       puppet_rules << fwr.provider.build_rich_rule
     end
     provider.get_rules.reject { |p| puppet_rules.include?(p) }.each do |purge|
+      self.debug("should purge rich rule #{purge}")
       purge_rules << Puppet::Type.type(:firewalld_rich_rule).new(
         :name     => purge,
         :raw_rule => purge,
@@ -48,6 +96,28 @@ Puppet::Type.newtype(:firewalld_zone) do
       )
     end
     return purge_rules
+  end
+  
+  def purge_services
+    return Array.new unless provider.exists?
+    purge_services = Array.new
+    puppet_services = Array.new
+    catalog.resources.select { |r| r.is_a?(Puppet::Type::Firewalld_service) }.each do |fws|
+      if fws[:zone] == self[:name]        
+        self.debug("not purging puppet controlled service #{fws[:service]}")
+        puppet_services << "#{fws[:service]}"
+      end
+    end
+    provider.get_services.reject { |p| puppet_services.include?(p) }.each do |purge|
+      self.debug("should purge service #{purge}")
+      purge_services << Puppet::Type.type(:firewalld_service).new(
+        :name     => "#{self[:name]}-#{purge}",
+        :ensure   => :absent,
+        :service  => purge,
+        :zone     => self[:name]
+      )
+    end
+    return purge_services
   end
 
 end

--- a/manifests/custom_service.pp
+++ b/manifests/custom_service.pp
@@ -1,0 +1,75 @@
+# == Type: firewalld::custom_service
+#
+# Creates a new service definition for use in firewalld
+#
+# See the README.md for usage instructions for this defined type
+#
+# === Examples
+#
+#    firewalld::custom_service{'My Custom Service':
+#      short       => 'MyService',
+#      description => 'My Custom Service is a daemon that does whatever',
+#      port        => [
+#        {
+#            'port'     => '1234'
+#            'protocol' => 'tcp'
+#        },
+#        {
+#            'port'     => '1234'
+#            'protocol' => 'udp'
+#        },
+#      ],
+#      module      => ['nf_conntrack_netbios_ns'],
+#      destination => {
+#        'ipv4' => '127.0.0.1',
+#        'ipv6' => '::1'
+#      }
+#    }
+#
+# === Authors
+#
+# Andrew Patik <andrewpatik@gmail.com>
+#
+#
+define firewalld::custom_service (
+  $short                = $name,
+  $description          = undef,
+  $port                 = undef, # Should be an array of hashes
+  $module               = undef, # Should be an array of strings
+  $destination          = undef,
+  $config_dir           = '/etc/firewalld/services',
+  $ensure               = 'present',
+) {
+
+  validate_string($short)
+  
+  if $description != undef {validate_string($description)}
+  if $module      != undef {validate_array($module)}
+  if $port        != undef {validate_array($port)}
+  if $destination != undef {
+    validate_hash($destination)
+    
+    if !has_key($destination, 'ipv4') and !has_key($destination, 'ipv6'){
+      fail('Parameter destination must contain at least one of "ipv4" and/or "ipv6" as keys in the hash')
+    }
+  }
+  validate_absolute_path($config_dir)
+  
+  firewalld_custom_service{"${$short}":
+    ensure => "${ensure}"
+  }
+  
+  exec{ 'firewalld::custom_service::reload':
+      path        =>'/usr/bin:/bin',
+      command     => 'firewall-cmd --complete-reload',
+      refreshonly => true,
+  }
+  
+  file{"${config_dir}/${$short}.xml":
+    ensure  => "${ensure}",
+    content => template('firewalld/service.xml.erb'),
+    mode    => '0644',
+    notify  => Exec['firewalld::custom_service::reload'],
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,8 @@
 {
   "name": "crayfishx-firewalld",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "author": "Craig Dunn",
-  "summary": "Configure firewalld zones and rich rules",
+  "summary": "Configure firewalld zones, services, and rich rules",
   "license": "Apache-2.0",
   "tags": [ "firewalld", "firewall" ],
   "operatingsystem_support": [
@@ -15,6 +15,10 @@
   "project_page": "https://github.com/crayfishx/puppet-firewalld",
   "issues_url": "https://github.com/crayfishx/puppet-firewalld/issues",
   "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": "\u003e\u003d 4.2.0"
+    }
   ]
 }
 

--- a/templates/service.xml.erb
+++ b/templates/service.xml.erb
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+    <short><%= @short %></short>
+    <%- if @description -%>
+    <description><%= @description %></description>
+    <%- end -%>
+    
+    <%- if @port -%>
+    <%- @port.each do |i| -%>
+    <port<% if i['protocol'] -%> protocol="<%= i['protocol'] %>"<% end -%><% if i['port'] -%> port="<%= i['port'] %>"<% end -%> />
+    <%- end -%>
+    
+    <%- end -%>
+    <%- if @module -%>
+    <%- @module.sort.each do |j| -%>
+    <module name="<%= j %>" />
+    <%- end -%>
+    
+    <%- end -%>
+    <%- if @destination -%>
+    <destination<% if @destination['ipv4'] -%> ipv4="<%= @destination['ipv4'] %>"<% end -%><% if @destination['ipv6'] -%> ipv6="<%= @destination['ipv6'] %>"<% end -%> />
+    <%- end -%>
+</service>


### PR DESCRIPTION
- firewalld_zone
	Added icmp_blocks parameter to manage any ICMP blocks for a zone (the proper way, instead of trying to hack it with a rich rule)
	Added purge_services parameter to purge any non-puppet managed services for a zone (pairs with the new firewalld_service type)
	The purge_rich_rules parameter is updated to be a little more loose in what values it accepts. true, 'true', and 'yes' should all be considered true, and false, 'false', and 'no' all considered false.

- firewalld_service
	New type to manage what services are assigned to a zone. Implemented as a separate type and not a parameter of firewalld_zone to allow flexibility in where the services are set. People using the common roles / profiles pattern would likely want to assign the service from the profile for the software that needs the service added, and not centrally in their standard zone declarations. It also makes it easier for people moving over from using the puppetlabs/firewall module on RHEL/CentOS 6.

- firewalld_rich_rule
	Added documentation, no functional changes.

- firewalld::init
	Parameterized the class, with parameters defaulting to the old assumed values for compatibility. This allows you to use the module without installing firewall-config and all it's associated GUI baggage on a gui-less server (among other things).

- firewalld::custom_service
	New defined type to create a custom service in firewalld.

- firewalld_custom_service
	New type to create a skeleton service entry in firewalld (used internally by firewalld::custom_service).

- metadata.json
	Updated with dependency on puppetlabs/stdlib, used by firewalld::custom_service for input validation
	Bumped up the version to 0.1.0. I believe everything is backwards compatible with any manifests written using the old version, so this is a feature version bump (second digit), and not a major version bump (first digit).

- README
	Updated with all the changes

Many dubugging lines were also added throughout the module. They will give you a better idea of what this module's resources are doing when the puppet agent is run in debug mode. They won't affect output in normal runs.

Note that this PR also handles the use case of the other currently open pull request, so if you accept this one, you can reject the other one.