### PR TITLE
fix errors resulting from target= when no target is defined.

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -25,9 +25,9 @@ Puppet::Type.type(:firewalld_zone).provide :firewall_cmd do
   end
 
   def create
-    self.debug("Creating new zone #{@resource[:name]}")
+    self.debug("Creating new zone #{@resource[:name]} with target: '#{@resource[:target]}'")
     exec_firewall('--new-zone', @resource[:name])
-    self.target=(@resource[:target]) 
+    self.target=(@resource[:target]) if @resource[:target]
   end
 
   def destroy


### PR DESCRIPTION
Currently within the firewalld_zone/firewall_cmd provider create calls self.target= without any check if @resource[:target] is present.
Since it is possible and valid to omit target from firewalld_zone resources, this case should be handled.
Without this case recent fedora and thus future rhel and centos firewalld versions will output an error:
Example:
Execution of '/bin/firewall-cmd --permanent --zone=monitoring --set-target ' returned 2: usage: see firewall-cmd man page
No option specified.

This patch adds a condition to only run firewall-cmd --set-target if the target has been defined. In addition it adds the current
target to the debug output of create.