### PR TITLE
Update formatting to better adhere to puppet-lint

### DIFF
--- a/manifests/custom_service.pp
+++ b/manifests/custom_service.pp
@@ -55,8 +55,8 @@ define firewalld::custom_service (
   }
   validate_absolute_path($config_dir)
   
-  file{"${config_dir}/${$short}.xml":
-    ensure  => "${ensure}",
+  file{"${config_dir}/${short}.xml":
+    ensure  => $ensure,
     content => template('firewalld/service.xml.erb'),
     mode    => '0644',
     notify  => Exec["firewalld::custom_service::reload-${name}"],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,21 +45,21 @@ class firewalld (
 
     # Further validation of string parameters
     if !($package_ensure in ['present','absent','latest','installed']) {
-      fail("Parameter package_ensure not set to valid value in module firewalld. Valid values are: present, absent, latest, installed. Value set: $package_ensure")
+      fail("Parameter package_ensure not set to valid value in module firewalld. Valid values are: present, absent, latest, installed. Value set: ${package_ensure}")
     }
     
     if !($service_ensure in ['stopped','running',]) {
-    fail("Parameter service_ensure not set to valid value in module firewalld. Valid values are: stopped, running. Value set: $service_ensure")
+    fail("Parameter service_ensure not set to valid value in module firewalld. Valid values are: stopped, running. Value set: ${service_ensure}")
   }
 
     package { $packages:
-      ensure => "${package_ensure}",
+      ensure => $package_ensure,
       notify => Service['firewalld']
     }
 
     service { 'firewalld':
-      ensure    => "${$service_ensure}",
-      enable    => $service_enable,
+      ensure => $service_ensure,
+      enable => $service_enable,
     }
 
     exec{ 'firewalld::reload':

--- a/tests/test.pp
+++ b/tests/test.pp
@@ -1,45 +1,51 @@
 
 
 firewalld_zone { 'testcraig':
-  target => '%%REJECT%%',
   ensure => present,
+  target => '%%REJECT%%',
 }
 
 firewalld_zone { 'restricted':
-  target => '%%REJECT%%',
   ensure => present,
+  target => '%%REJECT%%',
 }
 
 
 
 firewalld_rich_rule { 'Accept SSH from my box':
-  ensure => present,
-  family => 'ipv4',
-  zone   => 'restricted',
-  source => { 'address' => '10.0.1.2/24' },
-  service => 'ssh', 
+  ensure  => present,
+  family  => 'ipv4',
+  zone    => 'restricted',
+  source  => {
+    'address' => '10.0.1.2/24'
+  },
+  service => 'ssh',
   # log => true,
-  log => { 'level' => 'debug' },
-  action => 'accept',
+  log     => {
+    'level' => 'debug'
+  },
+  action  => 'accept',
 }
 
 # rule family="ipv4" source address="192.168.245.158/32" service name="ssh" accept
 
 firewalld_rich_rule { 'Already exists':
-  ensure => present,
-  family => 'ipv4',
-  zone   => 'restricted',
-  source => { 'address' => '192.168.245.158/32' },
+  ensure  => present,
+  family  => 'ipv4',
+  zone    => 'restricted',
+  source  => {
+    'address' => '192.168.245.158/32'
+  },
   service => 'ssh',
   log     => true,
   action  => 'accept',
 }
 
 firewalld_rich_rule { 'Already exists II':
-  ensure => present,
-  family => 'ipv4',
-  zone   => 'restricted',
-  source => '192.77.55.4/34',
+  ensure  => present,
+  family  => 'ipv4',
+  zone    => 'restricted',
+  source  => '192.77.55.4/34',
   service => 'ssh',
   action  => 'accept',
 }


### PR DESCRIPTION
This change updates a few minor formatting things to adhere to puppet-lint checks.

These should just be code formatting changes. There should be no changes to the actual code logic.