### PR TITLE
Add in the ability to use sources in a zone

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -15,6 +15,7 @@ Puppet::Type.newtype(:firewalld_zone) do
       firewalld_zone { 'restricted':
         ensure           => present,
         target           => '%%REJECT%%',
+        source           => ['192.168.0.0/24','fd1a:7ab7:631e:2480::/64'],
         purge_rich_rules => true,
         purge_services   => true,
         purge_ports      => true,
@@ -51,6 +52,17 @@ Puppet::Type.newtype(:firewalld_zone) do
 
   newparam(:zone) do
     desc "Name of the zone"
+  end
+
+  newproperty(:source, :array_matching => :all) do
+    desc "Source IP's of the zone"
+    def insync?(is)
+      case should
+        when String then should.lines.sort == is
+        when Array then should.sort == is
+        else raise Puppet::Error, "parameter source must be a string or array of strings!"
+      end
+    end
   end
 
   newproperty(:target) do

--- a/manifests/custom_service.pp
+++ b/manifests/custom_service.pp
@@ -42,26 +42,26 @@ define firewalld::custom_service (
 ) {
 
   validate_string($short)
-  
+
   if $description != undef {validate_string($description)}
   if $module      != undef {validate_array($module)}
   if $port        != undef {validate_array($port)}
   if $destination != undef {
     validate_hash($destination)
-    
+
     if !has_key($destination, 'ipv4') and !has_key($destination, 'ipv6'){
       fail('Parameter destination must contain at least one of "ipv4" and/or "ipv6" as keys in the hash')
     }
   }
   validate_absolute_path($config_dir)
-  
+
   file{"${config_dir}/${short}.xml":
     ensure  => $ensure,
     content => template('firewalld/service.xml.erb'),
     mode    => '0644',
     notify  => Exec["firewalld::custom_service::reload-${name}"],
   }
-  
+
   exec{ "firewalld::custom_service::reload-${name}":
     path        =>'/usr/bin:/bin',
     command     => 'firewall-cmd --reload',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class firewalld (
     if !($package_ensure in ['present','absent','latest','installed']) {
       fail("Parameter package_ensure not set to valid value in module firewalld. Valid values are: present, absent, latest, installed. Value set: ${package_ensure}")
     }
-    
+
     if !($service_ensure in ['stopped','running',]) {
     fail("Parameter service_ensure not set to valid value in module firewalld. Valid values are: stopped, running. Value set: ${service_ensure}")
   }

--- a/tests/test.pp
+++ b/tests/test.pp
@@ -67,5 +67,5 @@ firewalld_rich_rule { 'Already exists II':
 #    'port' => '929'
 #  },
 # }
-#  
-#  
+#
+#


### PR DESCRIPTION
I don't have a lot of experience programming, so please check this code carefully

This will add in the ability to allow for sources in the zone config..the idea behind
this is you can add a service of ssh to the zone and specify the ip range in there

  firewalld_zone { 'management':
    ensure           => present,
    target           => 'default',
    source           => ['192.168.0.0/24','fd1a:7ab7:631e:2480::/64'],
    purge_services   => true,
  }

  firewalld_service { 'Add ssh service to management IPs':
    ensure  => 'present',
    service => 'ssh',
    zone    => 'management',
  }

produces...

firewall-cmd --zone=management --list-all
management
  interfaces:
  sources: 192.168.0.0/24 fd1a:7ab7:631e:2480::/64
  services: ssh
  ports:
  masquerade: no
  forward-ports:
  icmp-blocks:
  rich rules:


Also have fixed the following puppet-lint issues
modules/firewalld/manifests/custom_service.pp:45: trailing whitespace.
modules/firewalld/manifests/custom_service.pp:51: trailing whitespace.
modules/firewalld/manifests/custom_service.pp:57: trailing whitespace.
modules/firewalld/manifests/custom_service.pp:64: trailing whitespace.
modules/firewalld/manifests/init.pp:50: trailing whitespace.
modules/firewalld/tests/test.pp:70: trailing whitespace.
modules/firewalld/tests/test.pp:71: trailing whitespace.