### PR TITLE
Fixed multiple problems with firewalld_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,10 @@ _Example_:
 
 ```puppet
   firewalld_port { 'Open port 8080 in the public zone':
-    ensure => present,
-    zone => 'public',
-    port => {
-      'port' => 8080,
-      'protocol' => 'tcp',
-    },
+    ensure   => present,
+    zone     => 'public',
+    port     => 8080,
+    protocol => 'tcp',
   }
 ```
 

--- a/lib/puppet/provider/firewalld_port/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_port/firewall_cmd.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:firewalld_port).provide :firewall_cmd do
   
   def eval_port
     args = []
-    args << ["#{@resource[:port]['port']}", @resource[:port]['protocol']].join("/")
+    args << "#{@resource[:port]}/#{@resource[:protocol]}"
     args
   end
   

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -117,6 +117,14 @@ Puppet::Type.type(:firewalld_zone).provide :firewall_cmd do
   def get_services
     zone_exec_firewall('--list-services').split(' ')
   end
+
+  def get_ports
+    zone_exec_firewall('--list-ports').split(' ').map do |entry|
+      port,protocol = entry.split(/\//)
+      self.debug("get_ports() Found port #{port} protocol #{protocol}")
+      { "port" => port, "protocol" => protocol }
+    end
+  end
   
   def get_icmp_blocks
     zone_exec_firewall('--list-icmp-blocks').split(' ').sort

--- a/lib/puppet/type/firewalld_port.rb
+++ b/lib/puppet/type/firewalld_port.rb
@@ -8,12 +8,10 @@ Puppet::Type.newtype(:firewalld_port) do
     Example:
     
         firewalld_port {'Open port 8080 in the public Zone':
-            ensure => 'present',
-            zone   => 'public',
-            port   => {
-              'port' => 8080,
-              'protocol' => 'tcp',
-            },
+            ensure   => 'present',
+            zone     => 'public',
+            port     => 8080,
+            protocol => 'tcp',
         }
   }
   

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -142,8 +142,6 @@ Puppet::Type.newtype(:firewalld_zone) do
         puppet_ports << { "port" => fwp[:port], "protocol" => fwp[:protocol] }
       end
     end
-  self.debug(provider.get_ports)
-  self.debug(puppet_ports)
     provider.get_ports.reject { |p| puppet_ports.include?(p) }.each do |purge|
       self.debug("Should purge port #{purge['port']} proto #{purge['protocol']}")
       purge_ports << Puppet::Type.type(:firewalld_port).new(


### PR DESCRIPTION
This PR should fix issues mentioned in #24 

* firewalld_zone { ... purge_ports => true } fixed
* port and protocol are now separate parameters, port will no longer accept a hash

eg: this....

    firewalld_port { 'foo':
      port => { "port" => "80", "protocol" => "tcp" }
    }

will no longer work - I'm not sure why it was in the documentation like this in the first place - it worked for create but not a lot more.   The proper way of declaring this should be 

    firewalld_port { 'foo':
      port => "80",
      protocol => "tcp"
    }
