### PR TITLE
Force the port attribute of firewalld_port to be a string.

### DIFF
--- a/lib/puppet/type/firewalld_port.rb
+++ b/lib/puppet/type/firewalld_port.rb
@@ -27,6 +27,9 @@ Puppet::Type.newtype(:firewalld_port) do
   
   newparam(:port) do
     desc "Specify the element as a port"
+    munge do |value|
+      value.to_s
+    end
   end
 
   newparam(:protocol) do


### PR DESCRIPTION
There is an issue with how firewalld ports are purged (if firewalld_zone has "purge_ports" set to true).  The issue arrises if you have integer data coming from a data binding such as hiera

If you take this hiera data;

    firewalld::zones:
      ports:
          "HTTP":
            port: 80
            protocol: 'tcp'
            ensure: 'present'
            zone:   'restricted'

When `firewalld_zone` has `purge` set to `true` the type will go through the catalog and "protect" those ports found, it then quieres the provider for known ports on the system and those that are not protected (eg: in the catalog) get dropped.  It does this by comparing the data from the provider with the data in the catalog.   The provider will return a hash of string elements, eg:

    { :port => "80", :protocol => "tcp" }

If a data binding sets the port value as an integer, as in our example, this makes it through into the catalog and the comparrison fails.

    { :port => "80", :protocol => "tcp" } != { :port => 80, :protocol => "tcp" }

This causes the module to continuously create and then remove firewalld port entries.

This PR fixes the issue by forcing the port parameter of the firewalld_port type to always be a string regardless of what the data binding gave.  An interim workaround for previous version of this module would be to always make sure your port is a string in your source data...

        port: "80"

Note this issue is not seen when declaring the class with integers within the Puppet manifests, only from data binding lookups.


