### PR TITLE
Update firewalld::reload to use --reload by default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,8 +82,15 @@ class firewalld (
 
     exec { 'firewalld::reload':
       path        =>'/usr/bin:/bin',
+      command     => 'firewall-cmd --reload',
+      refreshonly => true,
+    }
+
+    exec { 'firewalld::complete-reload':
+      path        =>'/usr/bin:/bin',
       command     => 'firewall-cmd --complete-reload',
       refreshonly => true,
+      require     => Exec['firewalld::reload'],
     }
 
     create_resources('firewalld_port',      $ports)


### PR DESCRIPTION
Update firewalld::reload to use --reload by default and create a firewalld::comlete-reload for use with --complete-reload.

This resolves Issue #57

From the firewalld man page.

   --reload
       Reload firewall rules and keep state information. Current permanent
       configuration will become new runtime configuration, i.e. all
       runtime only changes done until reload are lost with reload if they
       have not been also in permanent configuration.

   --complete-reload
       Reload firewall completely, even netfilter kernel modules. This
       will most likely terminate active connections, because state
       information is lost. This option should only be used in case of
       severe firewall problems. For example if there are state
       information problems that no connection can be established with
       correct firewall rules.