### PR TITLE
PROPOSED: Gather running and permanent rules when deciding to purge

### DIFF
--- a/lib/puppet/provider/firewalld_direct_purge/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_purge/firewall_cmd.rb
@@ -9,8 +9,9 @@ Puppet::Type.type(:firewalld_direct_purge).provide(
 
   def get_instances_of(restype)
     raise Puppet::Error, "Unknown type #{restype}" unless [:chain, :passthrough, :rule].include?(restype)
-    output = execute_firewall_cmd(['--direct',"--get-all-#{restype.to_s}s"], nil)
-    output.split(/\n/)
+    perm = execute_firewall_cmd(['--direct',"--get-all-#{restype.to_s}s"], nil).split(/\n/)
+    curr = execute_firewall_cmd(['--direct',"--get-all-#{restype.to_s}s"], nil, false).split(/\n/)
+    [ perm, curr ].flatten.uniq
   end
 
   def purge_resources(restype, args)

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -131,15 +131,22 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def get_rules
-    execute_firewall_cmd(['--list-rich-rules']).split(/\n/)
+    perm = execute_firewall_cmd(['--list-rich-rules']).split(/\n/)
+    curr = execute_firewall_cmd(['--list-rich-rules'], @resource[:name], false).split(/\n/)
+    [ perm, curr ].flatten.uniq
   end
 
   def get_services
-    execute_firewall_cmd(['--list-services']).split(' ')
+    perm = execute_firewall_cmd(['--list-services']).split(' ')
+    curr = execute_firewall_cmd(['--list-services'], @resource[:name], false).split(' ')
+    [ perm, curr ].flatten.uniq
   end
 
   def get_ports
-    execute_firewall_cmd(['--list-ports']).split(' ').map do |entry|
+    perm = execute_firewall_cmd(['--list-ports']).split(' ')
+    curr = execute_firewall_cmd(['--list-ports'], @resource[:name], false).split(' ')
+
+    [ perm, curr ].flatten.uniq.map do |entry|
       port,protocol = entry.split(/\//)
       self.debug("get_ports() Found port #{port} protocol #{protocol}")
       { "port" => port, "protocol" => protocol }

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -28,17 +28,24 @@ Puppet::Type.newtype(:firewalld_zone) do
   ensurable
 
 
+  # When set to 1 these variables cause the purge_* options to indicate to Puppet
+  # that we are in a changed state
+  #
+  attr_reader :rich_rules_purgable
+  attr_reader :services_purgable
+  attr_reader :ports_purgable
+
   def generate
 
     resources = Array.new
 
-    if self.purge_rich_rules?
+    if self[:purge_rich_rules] == :true
       resources.concat(purge_rich_rules())
     end
-    if self.purge_services?
+    if self[:purge_services] == :true
       resources.concat(purge_services())
     end
-    if self.purge_ports?
+    if self[:purge_ports] == :true
       resources.concat(purge_ports())
     end
 
@@ -104,24 +111,50 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
   end
 
-  newparam(:purge_rich_rules, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:purge_rich_rules) do
     desc "When set to true any rich_rules associated with this zone
           that are not managed by Puppet will be removed.
          "
-    defaultto :false
+    newvalue(:false)
+    newvalue(:true) do
+      true
+    end
+
+    def retrieve
+      return :false if @resource[:purge_rich_rules] == :false
+      provider.resource.rich_rules_purgable ? :purgable : :true
+    end
+     
   end
 
-  newparam(:purge_services, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:purge_services) do
+
     desc "When set to true any services associated with this zone
           that are not managed by Puppet will be removed.
          "
-    defaultto :false
+    newvalue(:false)
+    newvalue(:true) do
+      true
+    end
+
+    def retrieve
+      return :false if @resource[:purge_services] == :false
+      provider.resource.services_purgable ? :purgable : :true
+    end
   end
 
-  newparam(:purge_ports, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:purge_ports) do
     desc "When set to true any ports associated with this zone
           that are not managed by Puppet will be removed."
-    defaultto :false
+    newvalue (:false)
+    newvalue(:true) do
+      true
+    end
+
+    def retrieve 
+      return :false if @resource[:purge_ports] == :false
+      provider.resource.ports_purgable  ? :purgable : :true
+    end
   end
 
   def purge_rich_rules
@@ -134,15 +167,26 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
     provider.get_rules.reject { |p| puppet_rules.include?(p) }.each do |purge|
       self.debug("should purge rich rule #{purge}")
-      purge_rules << Puppet::Type.type(:firewalld_rich_rule).new(
+      res_type = Puppet::Type.type(:firewalld_rich_rule).new(
         :name     => purge,
         :raw_rule => purge,
         :ensure   => :absent,
         :zone     => self[:name]
       )
+
+      # If the rule exists in --permanent then we should purge it
+      #  
+      purge_rules << res_type if res_type.provider.exists?
+ 
+      # Even if it doesn't exist, it may be a running rule, so we
+      # flag purge_rich_rules as changed so Puppet will reload
+      # the firewall and drop orphaned running rules
+      #
+      @rich_rules_purgable = true
+      
+
     end
     return purge_rules
-
   end
 
   def purge_services
@@ -157,12 +201,15 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
     provider.get_services.reject { |p| puppet_services.include?(p) }.each do |purge|
       self.debug("should purge service #{purge}")
-      purge_services << Puppet::Type.type(:firewalld_service).new(
+      res_type = Puppet::Type.type(:firewalld_service).new(
         :name     => "#{self[:name]}-#{purge}",
         :ensure   => :absent,
         :service  => purge,
         :zone     => self[:name]
       )
+
+      purge_services << res_type if res_type.provider.exists?
+      @services_purgable = true
     end
     return purge_services
   end
@@ -179,13 +226,15 @@ Puppet::Type.newtype(:firewalld_zone) do
     end
     provider.get_ports.reject { |p| puppet_ports.include?(p) }.each do |purge|
       self.debug("Should purge port #{purge['port']} proto #{purge['protocol']}")
-      purge_ports << Puppet::Type.type(:firewalld_port).new(
+      res_type = Puppet::Type.type(:firewalld_port).new(
         :name     => "#{self[:name]}-#{purge['port']}-#{purge['protocol']}-purge",
         :port     => purge["port"],
         :ensure   => :absent,
         :protocol => purge["protocol"],
         :zone     => self[:name]
       )
+      purge_ports << res_type if res_type.provider.exists?
+      @ports_purgable = true
     end
     return purge_ports
   end

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -36,21 +36,10 @@ Puppet::Type.newtype(:firewalld_zone) do
   attr_reader :ports_purgable
 
   def generate
-
-    resources = Array.new
-
-    if self[:purge_rich_rules] == :true
-      resources.concat(purge_rich_rules())
-    end
-    if self[:purge_services] == :true
-      resources.concat(purge_services())
-    end
-    if self[:purge_ports] == :true
-      resources.concat(purge_ports())
-    end
-
-    return resources
-
+    purge_rich_rules if self[:purge_rich_rules] == :true
+    purge_services if self[:purge_services] == :true
+    purge_ports if self[:purge_ports] == :true
+    []
   end
 
 
@@ -176,7 +165,7 @@ Puppet::Type.newtype(:firewalld_zone) do
 
       # If the rule exists in --permanent then we should purge it
       #  
-      purge_rules << res_type if res_type.provider.exists?
+      res_type.provider.destroy if res_type.provider.exists?
  
       # Even if it doesn't exist, it may be a running rule, so we
       # flag purge_rich_rules as changed so Puppet will reload
@@ -186,7 +175,6 @@ Puppet::Type.newtype(:firewalld_zone) do
       
 
     end
-    return purge_rules
   end
 
   def purge_services
@@ -208,10 +196,9 @@ Puppet::Type.newtype(:firewalld_zone) do
         :zone     => self[:name]
       )
 
-      purge_services << res_type if res_type.provider.exists?
+      res_type.provider.destroy if res_type.provider.exists?
       @services_purgable = true
     end
-    return purge_services
   end
 
   def purge_ports
@@ -233,10 +220,9 @@ Puppet::Type.newtype(:firewalld_zone) do
         :protocol => purge["protocol"],
         :zone     => self[:name]
       )
-      purge_ports << res_type if res_type.provider.exists?
+      res_type.provider.destroy if res_type.provider.exists?
       @ports_purgable = true
     end
-    return purge_ports
   end
 
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,6 +155,10 @@ class firewalld (
       }
     }
 
+    Firewalld_direct_purge {
+      notify => Exec['firewalld::reload'],
+    }
+
     if $purge_direct_chains {
       firewalld_direct_purge { 'chain': }
     }

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:firewalld_zone) do
     context 'with no params' do
       describe 'when validating attributes' do
         [  
-          :name, :purge_rich_rules, :purge_services, :purge_ports
+          :name
         ].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:param)
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:firewalld_zone) do
       
   
         [  
-          :target, :icmp_blocks, :sources
+          :target, :icmp_blocks, :sources, :purge_rich_rules, :purge_services, :purge_ports
         ].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:property)


### PR DESCRIPTION

This is a proposal to bring back the slightly accidental behaviour described in https://github.com/crayfishx/puppet-firewalld/issues/26#issuecomment-239614108 from 2.2.0

This ensures that we always purge running rules (they get purged by the --reload)

#26 has the discussion on this.....