### PR TITLE
Changed load paths for relative paths in firewalld_direct_purge.rb

### DIFF
--- a/lib/puppet/type/firewalld_direct_purge.rb
+++ b/lib/puppet/type/firewalld_direct_purge.rb
@@ -1,8 +1,8 @@
 require 'puppet'
 require 'puppet/parameter/boolean'
-require File.dirname(__FILE__).concat('/firewalld_direct_chain.rb')
-require File.dirname(__FILE__).concat('/firewalld_direct_rule.rb')
-require File.dirname(__FILE__).concat('/firewalld_direct_passthrough.rb')
+require File.join(File.dirname(__FILE__),'firewalld_direct_chain.rb')
+require File.join(File.dirname(__FILE__),'firewalld_direct_rule.rb')
+require File.join(File.dirname(__FILE__),'firewalld_direct_passthrough.rb')
 
 Puppet::Type.newtype(:firewalld_direct_purge) do
 

--- a/lib/puppet/type/firewalld_direct_purge.rb
+++ b/lib/puppet/type/firewalld_direct_purge.rb
@@ -1,8 +1,8 @@
 require 'puppet'
 require 'puppet/parameter/boolean'
-require 'puppet/type/firewalld_direct_chain'
-require 'puppet/type/firewalld_direct_rule'
-require 'puppet/type/firewalld_direct_passthrough'
+require File.dirname(__FILE__).concat('/firewalld_direct_chain.rb')
+require File.dirname(__FILE__).concat('/firewalld_direct_rule.rb')
+require File.dirname(__FILE__).concat('/firewalld_direct_passthrough.rb')
 
 Puppet::Type.newtype(:firewalld_direct_purge) do
 

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -1,8 +1,8 @@
 require 'puppet'
 require 'puppet/parameter/boolean'
-require File.dirname(__FILE__).concat('/firewalld_rich_rule.rb')
-require File.dirname(__FILE__).concat('/firewalld_service.rb')
-require File.dirname(__FILE__).concat('/firewalld_port.rb')
+require File.join(File.dirname(__FILE__),'firewalld_rich_rule.rb')
+require File.join(File.dirname(__FILE__),'firewalld_service.rb')
+require File.join(File.dirname(__FILE__),'firewalld_port.rb')
 
 Puppet::Type.newtype(:firewalld_zone) do
 


### PR DESCRIPTION
This commit should fix problem when puppet agent getting compiled catalogs from puppetdb. With 3.1.1 version of crayfishx-firewalld I've got following error:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Type-Name, Could not autoload puppet/type/firewalld_direct_purge: no such file to load -- puppet/type/firewalld_direct_chain at /etc/puppetlabs/code/environments/test_firewalld_module/modules/firewalld/manifests/init.pp:144:5