### PR TITLE
munge arguments to support quoted args

### DIFF
--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -56,7 +56,7 @@ class Puppet::Provider::Firewalld < Puppet::Provider
     if args.is_a?(Array)
       args = args.flatten.join(" ")
     end
-    args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
+    args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
   end
 
   # Occasionally we need to restart firewalld in a transient way between resources

--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -53,6 +53,9 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   # in one element
   #
   def parse_args(args)
+    if args.is_a?(Array)
+      args = args.flatten.join(" ")
+    end
     args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
   end
 

--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -10,7 +10,10 @@ class Puppet::Provider::Firewalld < Puppet::Provider
     cmd_args = []
     cmd_args << '--permanent' if perm
     cmd_args << [ '--zone', zone ] unless zone.nil?
-    cmd_args << args
+
+    # Add the arguments to our command string, removing any quotes, the command
+    # provider will sort the quotes out.
+    cmd_args << args.flatten.map { |a| a.delete("'") }
 
     # We can't use the commands short cut as some things, like exists? methods need to
     # allow for the command to fail, and there is no way to override that.  So instead
@@ -43,6 +46,14 @@ class Puppet::Provider::Firewalld < Puppet::Provider
         raise e
       end
     end
+  end
+
+  # Arguments should be parsed as separate array entities, but quoted arg
+  # eg --log-prefix 'IPTABLES DROPPED' should include the whole quoted part
+  # in one element
+  #
+  def parse_args(args)
+    args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
   end
 
   # Occasionally we need to restart firewalld in a transient way between resources

--- a/lib/puppet/provider/firewalld_direct_purge/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_purge/firewall_cmd.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:firewalld_direct_purge).provide(
 
   def purge_resources(restype, args)
     raise Puppet::Error, "Unknown type #{restype}" unless [:chain, :passthrough, :rule].include?(restype)
-    execute_firewall_cmd(['--direct', "--remove-#{restype.to_s}", args], nil)
+    execute_firewall_cmd(['--direct', "--remove-#{restype.to_s}", parse_args(args)], nil)
   end
 
 end

--- a/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
@@ -30,8 +30,10 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
 	    @resource[:table],
 	    @resource[:chain],
 	    @resource[:priority].to_s,
-	    @resource[:args].split(" "),
+	    @resource[:args].split(/([^\s]*\'[^\']*\'| )/).delete_if(&:empty?).reject { |r| r == " " }.map { |x| x.gsub("\'", "") }
     ]
+    puts rule.flatten
+    p rule.flatten
     rule.flatten
   end
 

--- a/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
@@ -23,15 +23,6 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
     execute_firewall_cmd(['--direct', '--remove-rule', @rule_args], nil)
   end
 
-  # Arguments should be parsed as separate array entities, but quoted arg
-  # eg --log-prefix 'IPTABLES DROPPED' should include the whole quoted part
-  # in one element without the quotes.
-  #
-  def parse_args(args)
-    args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
-    args_array.map { |a| a.delete("'") }
-  end
-
 
   def generate_raw
     rule = []

--- a/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
@@ -23,6 +23,11 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
     execute_firewall_cmd(['--direct', '--remove-rule', @rule_args], nil)
   end
 
+  def parse_args(args)
+    args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
+    args_array.map { |a| a.delete("'") }
+  end
+
   def generate_raw
     rule = []
     rule << [
@@ -30,10 +35,8 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
 	    @resource[:table],
 	    @resource[:chain],
 	    @resource[:priority].to_s,
-	    @resource[:args].split(/([^\s]*\'[^\']*\'| )/).delete_if(&:empty?).reject { |r| r == " " }.map { |x| x.gsub("\'", "") }
+      parse_args(@resource[:args])
     ]
-    puts rule.flatten
-    p rule.flatten
     rule.flatten
   end
 

--- a/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
@@ -23,18 +23,23 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
     execute_firewall_cmd(['--direct', '--remove-rule', @rule_args], nil)
   end
 
+  # Arguments should be parsed as separate array entities, but quoted arg
+  # eg --log-prefix 'IPTABLES DROPPED' should include the whole quoted part
+  # in one element without the quotes.
+  #
   def parse_args(args)
     args_array = args.split(/(\'[^\']*\'| )/).reject { |r| [ "", " "].include?(r) }
     args_array.map { |a| a.delete("'") }
   end
 
+
   def generate_raw
     rule = []
     rule << [
-	    @resource[:inet_protocol],
-	    @resource[:table],
-	    @resource[:chain],
-	    @resource[:priority].to_s,
+      @resource[:inet_protocol],
+      @resource[:table],
+      @resource[:chain],
+      @resource[:priority].to_s,
       parse_args(@resource[:args])
     ]
     rule.flatten

--- a/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
@@ -70,7 +70,7 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
 
       it "should correctly parse arguments in quotes" do
         args="-j LOG --log-prefix '# IPTABLES DROPPED:'"
-        expect(provider.parse_args(args)).to eq(['-j', 'LOG', '--log-prefix', '# IPTABLES DROPPED:'])
+        expect(provider.parse_args(args)).to eq(['-j', 'LOG', '--log-prefix', '\'# IPTABLES DROPPED:\''])
       end
     end
 

--- a/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_direct_rule_spec.rb
@@ -61,5 +61,19 @@ describe Puppet::Type.type(:firewalld_direct_rule) do
       provider.expects(:execute_firewall_cmd).with(['--direct', '--remove-rule', [  'ipv4', 'filter', 'OUTPUT', '4', '-p', 'tcp', '--dport=22', '-j', 'ACCEPT']], nil)
       provider.destroy
     end
+
+    context "parsing arguments" do
+      it "should correctly parse arguments into an array" do
+        args="-p tcp --dport=22 -j ACCEPT"
+        expect(provider.parse_args(args)).to eq(['-p', 'tcp', '--dport=22', '-j', 'ACCEPT'])
+      end
+
+      it "should correctly parse arguments in quotes" do
+        args="-j LOG --log-prefix '# IPTABLES DROPPED:'"
+        expect(provider.parse_args(args)).to eq(['-j', 'LOG', '--log-prefix', '# IPTABLES DROPPED:'])
+      end
+    end
+
+
   end
 end


### PR DESCRIPTION

This is potential proposal to fix #82 - it needs some work

@gothicx can you confirm if this actually works for you? I see 

`  <rule priority="1" table="filter" ipv="ipv4" chain="LOG_DROPS">-j LOG --log-prefix '# IPTABLES DROPPED:'</rule>`

If that works, I'll try and tidy it up a bit before merging!
