### PR TITLE
#86 --get-icmptypes should not be run against the zone

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -159,7 +159,7 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def get_icmp_types
-    execute_firewall_cmd(['--get-icmptypes']).split(' ')
+    execute_firewall_cmd(['--get-icmptypes'], nil).split(' ')
   end
 
 end

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -102,5 +102,10 @@ describe Puppet::Type.type(:firewalld_zone) do
       expect(provider.icmp_blocks).to eq(['val'])
     end
 
+    it "should list icmp types" do
+      provider.expects(:execute_firewall_cmd).with(['--get-icmptypes'], nil).returns("echo-reply echo-request")
+      expect(provider.get_icmp_types).to eq(['echo-reply', 'echo-request'])
+    end
+
   end
 end


### PR DESCRIPTION

This addresses #86 

Smoke testing looks good...

```
Notice: /Stage[main]/Main/Firewalld_zone[restricted]/icmp_blocks: icmp_blocks changed [] to 'echo-request'
```