### PR TITLE
Removed lambda blocks from firewalld_direct_chain

### DIFF
--- a/lib/puppet/type/firewalld_direct_chain.rb
+++ b/lib/puppet/type/firewalld_direct_chain.rb
@@ -18,15 +18,14 @@ Puppet::Type.newtype(:firewalld_direct_chain) do
   ensurable
 
   def self.title_patterns
-    identity = lambda { |x| x }
     [
       [
         /^([^:]+):([^:]+):([^:]+)$/,
-        [ [:inet_protocol, identity], [:table, identity], [:name, identity] ]
+        [ [:inet_protocol], [:table], [:name] ]
       ],
       [
         /^([^:]+)$/,
-        [[ :name, identity ]]
+        [[ :name ]]
       ]
     ]
   end


### PR DESCRIPTION
puppet generate types does not support types that have procs in
their title_patterns, since this is not actually needed it's been
removed