### PR TITLE
Dont fail when firewall-cmd is not available yet.

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -12,6 +12,15 @@ Puppet::Type.type(:firewalld_zone).provide(
 
   def exists?
     @resource[:zone] = @resource[:name]
+
+    # If running is still set to nil then firewalld might not be installed yet,
+    # and we are probably calling this method from the generate method of the
+    # firewalld_zone type.  We should just politely return false here as the
+    # module should install the package later in the puppet run, related to
+    # issue #96
+    #
+    return false if running.nil?
+
     execute_firewall_cmd(['--get-zones'], nil).split(" ").include?(@resource[:name])
   end
 


### PR DESCRIPTION
If the firewalld package is not installed yet, then the module fails
because firewalld tries to determine the state of the firewalld process
by using the firewall-cmd command, also the firewalld_zone resource type
will try and call the provider.exists? method in the generate method.

Both of these steps occur before the catalog is applied so before the
package resource can install the package.

This PR catches the exception when the command is missing and leaves
the @running instance variable set to nil.... When determining the
state of the firewalld service later in the Puppet run, the state
is re-checked if @running is set to nil.

Closes #96