### PR TITLE
Changed ruby require to Puppet::Type API references for types

### DIFF
--- a/lib/puppet/type/firewalld_direct_purge.rb
+++ b/lib/puppet/type/firewalld_direct_purge.rb
@@ -1,10 +1,14 @@
 require 'puppet'
 require 'puppet/parameter/boolean'
-require File.join(File.dirname(__FILE__),'firewalld_direct_chain.rb')
-require File.join(File.dirname(__FILE__),'firewalld_direct_rule.rb')
-require File.join(File.dirname(__FILE__),'firewalld_direct_passthrough.rb')
 
 Puppet::Type.newtype(:firewalld_direct_purge) do
+
+
+  # Reference the types here so we know they are loaded.
+  #
+  Puppet::Type.type(:firewalld_direct_chain)
+  Puppet::Type.type(:firewalld_direct_rule)
+  Puppet::Type.type(:firewalld_direct_passthrough)
 
   @doc =%q{Allow to purge direct rules in iptables/ip6tables/ebtables using firewalld direct interface.
 

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -1,10 +1,13 @@
 require 'puppet'
 require 'puppet/parameter/boolean'
-require File.join(File.dirname(__FILE__),'firewalld_rich_rule.rb')
-require File.join(File.dirname(__FILE__),'firewalld_service.rb')
-require File.join(File.dirname(__FILE__),'firewalld_port.rb')
 
 Puppet::Type.newtype(:firewalld_zone) do
+
+  # Reference the types here so we know they are loaded
+  #
+  Puppet::Type.type(:firewalld_rich_rule)
+  Puppet::Type.type(:firewalld_service)
+  Puppet::Type.type(:firewalld_port)
 
   @doc =%q{Creates and manages firewald zones.
     Note that setting ensure => 'absent' to the built in firewalld zones will

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,6 +12,28 @@ describe 'firewalld' do
     it { should contain_class('firewalld') }
   end
 
+  context 'with purge options' do
+    let(:params) do
+      {
+        :purge_direct_rules => true,
+        :purge_direct_chains => true,
+        :purge_direct_passthroughs => true,
+      }
+    end
+
+    it do
+      should contain_firewalld_direct_purge('rule')
+    end
+
+    it do
+      should contain_firewalld_direct_purge('passthrough')
+    end
+
+    it do
+      should contain_firewalld_direct_purge('chain')
+    end
+  end
+
   context 'with parameter ports' do
     let(:params) do
       {


### PR DESCRIPTION
Changed ruby require to Puppet::Type API references for types

Closes #93

As noted in #93, under certain circumstances, depending on the ordering
of which things are evaluated first in the manifests, Puppet 4.5.0+ can
throw an exception because it tries to re-register the types.  This was
discussed in https://tickets.puppetlabs.com/browse/PUP-6922

This commit removes the require statements for firewalld types and
instead references them using the Puppet::Type API to make sure they are
loaded.
