### PR TITLE
Dropped puppet 3.x support and added 4.0 and 4.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: ruby
 bundler_args: --without acceptance
 script: "bundle exec rake test SPEC_OPTS='--format documentation'"
 env:
-  - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.7.5" FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.0.0"
   - PUPPET_VERSION="~> 4.1.0"
   - PUPPET_VERSION="~> 4.2.0"
   - PUPPET_VERSION="~> 4.3.0"
@@ -13,17 +11,9 @@ env:
   - PUPPET_VERSION="~> 4.5.0"
   - PUPPET_VERSION="~> 4.6.1"
   - PUPPET_VERSION="~> 4.7.0"
+  - PUPPET_VERSION="~> 4.8.0"
 rvm:
   - 1.9.3
   - 2.0
   - 2.1
   - 2.2
-matrix:
-  exclude:
-    - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-    - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.7.5" FUTURE_PARSER=yes
-    - rvm: 2.2
-      env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
-

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module manages firewalld, the userland interface that replaces iptables and
 
 ## Compatibility
 
-Latest versions of this module (3.0+) are only supported on Puppet 4.0+.  2.2.0 is the latest version to run on Puppet 3.x, important patches (security bugs..etc) will be accepted in the 2.x but new features will only be accepted in 3.x.
+Latest versions of this module (3.0+) are only supported on Puppet 4.0+.  2.2.0 is the latest version to run on Puppet 3.x, important patches (security bugs..etc) will be accepted in the 2.x until Puppet 3.x is offically end-of-life, but new features will only be accepted in 3.x.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 This module manages firewalld, the userland interface that replaces iptables and ships with RHEL7.  The module manages firewalld itself as well as providing types and providers for managing firewalld zones, ports, and rich rules.
 
+## Compatibility
+
+Latest versions of this module (3.0+) are only supported on Puppet 4.0+.  2.2.0 is the latest version to run on Puppet 3.x, important patches (security bugs..etc) will be accepted in the 2.x but new features will only be accepted in 3.x.
+
 ## Usage
 
 ```puppet


### PR DESCRIPTION

Puppet 3.x is EOL very soon and this module officially is only supported on >= 4.0 since the 3.0 release, although earlier versions of the firewalld 3.x series ran on Puppet 3 + future parser it was never the intent to actively support this.    3.1.7 introduced a change that included the `Puppet::MissingCommand` exception, which would cause a failure on Puppet 3.x, therefore, for clarity, this PR officially drops support for Puppet 3.x.