### PR TITLE
Evaluate target correctly when firewall-cmd --get-target doesn't use %%

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -30,7 +30,12 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def target
-    execute_firewall_cmd(['--get-target']).chomp
+    zone_target=execute_firewall_cmd(['--get-target']).chomp
+    # The firewall-cmd may or may not return the target surrounded by
+    # %% depending on the version. See:
+    # https://github.com/crayfishx/puppet-firewalld/issues/111
+    return @resource[:target] if @resource[:target].delete('%') == zone_target
+    zone_target
   end
 
   def target=(t)

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -55,6 +55,16 @@ describe Puppet::Type.type(:firewalld_zone) do
       expect(provider.exists?).to be_falsey
     end
 
+    it "should evalulate target" do
+      provider.expects(:execute_firewall_cmd).with(['--get-target']).returns('%%REJECT%%')
+      expect(provider.target).to eq('%%REJECT%%')
+    end
+
+    it "should evalulate target correctly when not surrounded with %%" do
+      provider.expects(:execute_firewall_cmd).with(['--get-target']).returns('REJECT')
+      expect(provider.target).to eq('%%REJECT%%')
+    end
+
     it "should create" do
       provider.expects(:execute_firewall_cmd).with(['--new-zone', 'restricted'], nil)
       provider.expects(:execute_firewall_cmd).with(['--set-target', '%%REJECT%%'])


### PR DESCRIPTION
Closes #111

https://github.com/crayfishx/puppet-firewalld/issues/111