### PR TITLE
Add support for ipset for zone files using rich_rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,22 @@ firewalld::rich_rules:
 
 * `family`: Protocol family, defaults to `ipv4`
 
-* `source`: Source address information. This can be a hash containing the keys `address` and `invert`, or a string containing just the IP address
+* `source`: Source address information. This can be a hash containing the keys `address or ipset` and `invert`, or a string containing just the IP address
   ```puppet
      source => '192.168.2.1',
 
      source => { 'address' => '192.168.1.1', 'invert' => true }
+     source => { 'ipset' => 'whitelist', 'invert' => true }
+     source => { 'ipset' => 'blacklist' }
   ```
 
-* `dest`: Destination address information. This can be a hash containing the keys `address` and `invert`, or a string containing just the IP address
+* `dest`: Destination address information. This can be a hash containing the keys `address or ipset` and `invert`, or a string containing just the IP address
   ```puppet
      dest => '192.168.2.1',
 
      dest => { 'address' => '192.168.1.1', 'invert' => true }
+     dest => { 'ipset' => 'whitelist', 'invert' => true }
+     dest => { 'ipset' => 'blacklist' }
   ```
 
 * `log`: When set to `true` will enable logging, optionally this can be hash with `prefix`, `level` and `limit`

--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -30,6 +30,7 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
     invert = addr['invert']  ? ' NOT' : ''
     args << "source#{invert}"
     args << quote_keyval('address', addr['address'])
+    args << quote_keyval('ipset', addr['ipset'])
     args
   end
 
@@ -39,6 +40,7 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
     invert = addr['invert']  ? ' NOT' : ''
     args << "destination#{invert}"
     args << quote_keyval('address', addr['address'])
+    args << quote_keyval('ipset', addr['ipset'])
     args
   end
 

--- a/lib/puppet/type/firewalld_rich_rule.rb
+++ b/lib/puppet/type/firewalld_rich_rule.rb
@@ -44,6 +44,10 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
       if value.is_a?(String)
         { 'address' => value }
       else
+        errormsg = "Only one source type address or ipset may be specified."
+        if value.has_key?("address") && value.has_key?("ipset")
+          self.fail errormsg
+        end
         value
       end
     end
@@ -54,6 +58,10 @@ Puppet::Type.newtype(:firewalld_rich_rule) do
       if value.is_a?(String)
         { 'address' => value }
       else
+        errormsg = "Only one source type address or ipset may be specified."
+        if value.has_key?("address") && value.has_key?("ipset")
+          self.fail errormsg
+        end
         value
       end
     end


### PR DESCRIPTION
This commit adds support for IPSETs for the source in rich_rules.

     firewalld_rich_rule { "block-ports-for-servers-not-in-whitelist":
        ensure   => 'present',
        zone     => 'public',
        family   => 'ipv4',
        source   => { 'ipset' => 'whitelist', 'invert' => true, },
        port     => { 'port' => $port, 'protocol' => 'tcp', },
        action   => 'reject',
      }

This is a partial implementation for issue  #108