### PR TITLE
Changed dependancy on set-default-zone exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,9 +168,9 @@ class firewalld (
 
     if $default_zone {
       exec { 'firewalld::set_default_zone':
-        command   => "firewall-cmd --set-default-zone ${default_zone}",
-        unless    => "[ $(firewall-cmd --get-default-zone) == ${default_zone} ]",
-        require   => Exec['firewalld::reload'],
+        command => "firewall-cmd --set-default-zone ${default_zone}",
+        unless  => "[ $(firewall-cmd --get-default-zone) == ${default_zone} ]",
+        require => Exec['firewalld::reload'],
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -170,7 +170,7 @@ class firewalld (
       exec { 'firewalld::set_default_zone':
         command   => "firewall-cmd --set-default-zone ${default_zone}",
         unless    => "[ $(firewall-cmd --get-default-zone) == ${default_zone} ]",
-        subscribe => Service['firewalld']
+        require   => Exec['firewalld::reload'],
       }
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,7 +23,7 @@ describe 'firewalld' do
       should contain_exec('firewalld::set_default_zone').with(
         :command => 'firewall-cmd --set-default-zone restricted',
         :unless  => '[ $(firewall-cmd --get-default-zone) == restricted ]',
-      ).that_subscribes_to('Service[firewalld]')
+      ).that_requires('Exec[firewalld::reload]')
     end
   end
 


### PR DESCRIPTION

This PR makes the set-default-zone exec resource always execute after the firewall has reloaded.

Closes #135 