### PR TITLE
Sort "is" array in sources insync method

### DIFF
--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -82,8 +82,8 @@ Puppet::Type.newtype(:firewalld_zone) do
 
     def insync?(is)
       case should
-      when String then should.lines.sort == is
-      when Array then should.sort == is
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
       else raise Puppet::Error, "parameter sources must be a string or array of strings!"
       end
     end


### PR DESCRIPTION
Seemingly after an update to RHEL 7.4 from 7.3, the `firewalld_zone` resource type began reloading `firewalld`, claiming that zone sources were not in sync. Nothing had changed and the message was really strange:

```
Notice: /Stage[main]/Profile::Remote_access/Firewalld_zone[campus]/sources: sources changed '[152.14.0.0/16, 152.7.0.0/16, 10.0.0.0/8, 152.1.0.0/16]' to '[152.14.0.0/16, 152.7.0.0/16, 10.0.0.0/8, 152.1.0.0/16]'
```
Note that there is no difference in `should` and `is` in this case. I tried changing the order of things in what eventually makes its way to `should`, but it did not matter.

This patch sorts `is` when compared to `should` in determining whether or not the `source` property is `insync`. Below are before and after Puppet agent runs.

**Before:**

```
[root@testbed3 ~]# puppet agent -t
Info: Using configured environment 'mdwheele_firewalld_patch'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for testbed3.eos.ncsu.edu
Info: Applying configuration version '1501704652'
Notice: /Stage[main]/Profile::Remote_access/Firewalld_zone[campus]/sources: sources changed '[152.14.0.0/16, 152.7.0.0/16, 10.0.0.0/8, 152.1.0.0/16]' to '[152.14.0.0/16, 152.7.0.0/16, 10.0.0.0/8, 152.1.0.0/16]'
Info: /Stage[main]/Profile::Remote_access/Firewalld_zone[campus]: Scheduling refresh of Exec[firewalld::reload]
Notice: /Stage[main]/Firewalld/Exec[firewalld::reload]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 16.88 seconds
```

**After applying this patch:**

```
[root@testbed3 ~]# puppet agent -t
Info: Using configured environment 'mdwheele_firewalld_patch'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/opt/puppetlabs/puppet/cache/lib/puppet/type/firewalld_zone.rb]/content: 
--- /opt/puppetlabs/puppet/cache/lib/puppet/type/firewalld_zone.rb	2017-08-02 16:10:42.254659827 -0400
+++ /tmp/puppet-file20170802-6148-1i4kg2i	2017-08-02 16:11:51.124384296 -0400
@@ -82,8 +82,8 @@
 
     def insync?(is)
       case should
-      when String then should.lines.sort == is
-      when Array then should.sort == is
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
       else raise Puppet::Error, "parameter sources must be a string or array of strings!"
       end
     end

Notice: /File[/opt/puppetlabs/puppet/cache/lib/puppet/type/firewalld_zone.rb]/content: content changed '{md5}60be6ca729f530f91198b37066537ffa' to '{md5}744041c0c17114691d5ab5cf18672312'
Info: Loading facts
Info: Caching catalog for testbed3.eos.ncsu.edu
Info: Applying configuration version '1501704721'
Notice: Applied catalog in 16.45 seconds
```

I do not believe this should cause any backwards incompatibilities and, in fact, I have noticed no change in behaviour on other RHEL / CentOS 7.3 test machines I am working on. 