### PR TITLE
Ensure sources always sorts alphanumerically

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -62,7 +62,7 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def sources
-    execute_firewall_cmd(['--list-sources']).chomp.split(" ") || []
+    execute_firewall_cmd(['--list-sources']).chomp.split(" ").sort || []
   end
 
   def sources=(new_sources)

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -105,6 +105,12 @@ describe Puppet::Type.type(:firewalld_zone) do
         expect(provider.sources).to eq(["val", "val"])
       end
 
+
+      it "sources should always return in alphanumerical order" do
+        provider.expects(:execute_firewall_cmd).with(['--list-sources']).returns("4.4.4.4/32 2.2.2.2/32 3.3.3.3/32")
+        expect(provider.sources).to eq(["2.2.2.2/32", "3.3.3.3/32","4.4.4.4/32"])
+      end
+
       it "should set sources" do
         provider.expects(:sources).returns(["valx"])
         provider.expects(:execute_firewall_cmd).with(['--add-source', 'valy'])


### PR DESCRIPTION
In later versions of firewalld (tested on `firewalld-0.4.4.5-1.fc26`) the `--list-sources` option for a zone seems to return entries in the order they were added - whereas previous versions used to always return in order - this affects the module being able to determine if the resource is insync, as noted in #146 

Closes #146 

This PR ensures the provider always sorts the output of the command from the firewall-cmd command
