### PR TITLE
list-interfaces does not support permanent option

### DIFF
--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -45,7 +45,7 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def interfaces
-    execute_firewall_cmd(['--list-interfaces']).chomp.split(" ") || []
+    execute_firewall_cmd(['--list-interfaces'], @resource[:name], false).chomp.split(" ") || []
   end
 
   def interfaces=(new_interfaces)
@@ -186,4 +186,3 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
 end
-

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -92,7 +92,7 @@ describe Puppet::Type.type(:firewalld_zone) do
       end
 
       it "should get interfaces" do
-        provider.expects(:execute_firewall_cmd).with(['--list-interfaces']).returns("")
+        provider.expects(:execute_firewall_cmd).with(['--list-interfaces'], 'restricted', false).returns("")
         provider.interfaces
       end
 


### PR DESCRIPTION
This fixes issue #143 by retrieving the interfaces attached to a zone without the `--permanent` parameter.

According to the Fedora Docs, Zones do not support the `--permanent` option and an empty interface list is returned instead causing the module to try to add the interface to the zone again.

See: [Fedora Docs Firewalld](https://fedoraproject.org/wiki/Firewalld?rd=FirewallD#Generic_use)

>Add an interface to a zone
>`firewall-cmd [--zone=<zone>] --add-interface=<interface>`
>Add an interface to a zone, if it was not in a zone before. If the zone options is omitted, the default zone will be used. **The interfaces are reapplied after reloads.**

This has been tested on CentOS `7.4.1708 (Core)`