### PR TITLE
Fix ordering when checking insync

### DIFF
--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -3,9 +3,9 @@ Puppet::Type.newtype(:firewalld_ipset) do
 
   @doc =%q{
     Configure IPsets in Firewalld
-    
+
     Example:
-    
+
         firewalld_port {'Open port 8080 in the public Zone':
             ensure   => 'present',
             zone     => 'public',
@@ -13,16 +13,16 @@ Puppet::Type.newtype(:firewalld_ipset) do
             protocol => 'tcp',
         }
   }
-  
+
   ensurable
-  
+
   newparam(:name, :namevar => true) do
     desc "Name of the IPset"
     validate do |val|
       raise Puppet::Error, "IPset name must be a word with no spaces" unless val =~ /^\w+$/
     end
   end
-  
+
   newparam(:type) do
     desc "Type of the ipset (default: hash:ip)"
     defaultto "hash:ip"
@@ -38,9 +38,9 @@ Puppet::Type.newtype(:firewalld_ipset) do
   newproperty(:entries, :array_matching => :all) do
     desc "Array of ipset entries"
     def insync?(is)
-      should.sort == is
+      should.sort == is.sort
     end
   end
 
 end
-  
+

--- a/lib/puppet/type/firewalld_zone.rb
+++ b/lib/puppet/type/firewalld_zone.rb
@@ -64,8 +64,8 @@ Puppet::Type.newtype(:firewalld_zone) do
 
     def insync?(is)
       case should
-      when String then should.lines.sort == is
-      when Array then should.sort == is
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
       else raise Puppet::Error, "parameter interfaces must be a string or array of strings!"
       end
     end
@@ -82,8 +82,8 @@ Puppet::Type.newtype(:firewalld_zone) do
 
     def insync?(is)
       case should
-      when String then should.lines.sort == is
-      when Array then should.sort == is
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
       else raise Puppet::Error, "parameter sources must be a string or array of strings!"
       end
     end
@@ -102,11 +102,11 @@ Puppet::Type.newtype(:firewalld_zone) do
           or an array of strings specifying multiple icmp types. Any blocks not specified here will be removed
          "
     def insync?(is)
-        case should
-            when String then should.lines.sort == is
-            when Array then should.sort == is
-            else raise Puppet::Error, "parameter icmp_blocks must be a string or array of strings!"
-        end
+      case should
+      when String then should.lines.sort == is.sort
+      when Array then should.sort == is.sort
+      else raise Puppet::Error, "parameter icmp_blocks must be a string or array of strings!"
+      end
     end
   end
 
@@ -123,7 +123,7 @@ Puppet::Type.newtype(:firewalld_zone) do
       return :false if @resource[:purge_rich_rules] == :false
       provider.resource.rich_rules_purgable ? :purgable : :true
     end
-     
+
   end
 
   newproperty(:purge_services) do
@@ -150,7 +150,7 @@ Puppet::Type.newtype(:firewalld_zone) do
       true
     end
 
-    def retrieve 
+    def retrieve
       return :false if @resource[:purge_ports] == :false
       provider.resource.ports_purgable  ? :purgable : :true
     end
@@ -184,15 +184,15 @@ Puppet::Type.newtype(:firewalld_zone) do
       )
 
       # If the rule exists in --permanent then we should purge it
-      #  
+      #
       purge_resource(res_type)
- 
+
       # Even if it doesn't exist, it may be a running rule, so we
       # flag purge_rich_rules as changed so Puppet will reload
       # the firewall and drop orphaned running rules
       #
       @rich_rules_purgable = true
-      
+
 
     end
   end


### PR DESCRIPTION
`is` is not guaranteed to be sorted so we need to sort it before comparing to `should.sort`


Initially noticed on Centos 7.4 with zone interfaces:

```bash
# c7.3
$ firewall-cmd --permanent --list-interfaces --zone=trusted
eno1 enp22s0 enp2s0f0 enp4s0 enp6s0f0 enp80s0f0 ens1 ens1f0 ens2f0 ens6
# c7.4
$ firewall-cmd --permanent --list-interfaces --zone=trusted
ens6 enp2s0f0 ens1 enp22s0 enp4s0 enp6s0f0 eno1 ens2f0 ens1f0 enp80s0f0
```

Firewalld returns the output of a Python `<dict>.keys()` call which gives a non random but arbitrary order.

* [Firewalld code](https://github.com/firewalld/firewalld/blob/master/src/firewall/core/fw_zone.py#L522)
* [Python docs on dict](https://docs.python.org/2/library/stdtypes.html#dict.items) (note dict.keys redirects to dict.items note)