### PR TITLE
Add defaults for services and ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ class { 'firewalld': }
 * `service_ensure`: Whether the service should be running or not (default: running)
 * `service_enable`: Whether to enable the service
 * `default_zone`: Optional, set the default zone for interfaces (default: undef)
+* `default_service_zone`: Optional, set the default zone for services (default: undef)
+* `default_port_zone`: Optional, set the default zone for ports (default: undef)
+* `default_port_protocol`: Optional, set the default protocol for ports (default: undef)
 * `log_denied`: Optional, (firewalld-0.4.3.2-8+) Log denied packets, can be one of `off`, `all`, `multicast`, `unicast`, `broadcast` (default: undef)
 * `zones`: A hash of [firewalld zones](#firewalld-zones) to configure
 * `ports`: A hash of [firewalld ports](#firewalld-ports) to configure
@@ -335,9 +338,11 @@ firewalld::services:
 
 #### Parameters
 
-* `service`: Name of the service to manage
+* `service`: Name of the service to manage, defaults to the resource name.
 
-* `zone`: Name of the zone in which you want to manage the service
+* `zone`: Name of the zone in which you want to manage the service, defaults to parameter `default_service_zone` of class `firewalld` if specified.
+
+* `ensure`: Whether to add (`present`) or remove the service (`absent`), defaults to `present`.
 
 
 ## Firewalld Ipsets
@@ -401,15 +406,13 @@ firewalld::ports:
 
 #### Parameters
 
-* `zone`: Name of the zone this port belongs to
+* `zone`: Name of the zone this port belongs to, defaults to parameter `default_port_zone` of class `firewalld` if specified.
 
-* `port`: A hash containing `port` and `protocol` values
-```puppet
-  port => {
-    'port' => 8080,
-    'protocol' => 'tcp',
-  },
-```
+* `port`: The port to manage, defaults to the resource name.
+
+* `protocol`: The protocol this port uses, e.g. `tcp` or `udp`, defaults to parameter `default_port_protocol` of class `firewalld` if specified.
+
+* `ensure`: Whether to add (`present`) or remove the service (`absent`), defaults to `present`.
 
 ## Firewalld Direct Chains
 

--- a/lib/puppet/type/firewalld_port.rb
+++ b/lib/puppet/type/firewalld_port.rb
@@ -15,7 +15,17 @@ Puppet::Type.newtype(:firewalld_port) do
         }
   }
   
-  ensurable
+  ensurable do
+    newvalue(:present) do
+      @resource.provider.create
+    end
+
+    newvalue(:absent) do
+      @resource.provider.destroy
+    end
+
+    defaultto(:present)
+  end
   
   newparam(:name, :namevar => true) do
     desc "Name of the port resource in Puppet"
@@ -27,6 +37,7 @@ Puppet::Type.newtype(:firewalld_port) do
   
   newparam(:port) do
     desc "Specify the element as a port"
+    defaultto { @resource[:name] }
     munge do |value|
       value.to_s
     end

--- a/lib/puppet/type/firewalld_service.rb
+++ b/lib/puppet/type/firewalld_service.rb
@@ -16,7 +16,17 @@ Puppet::Type.newtype(:firewalld_service) do
 
   }
 
-  ensurable
+  ensurable do
+    newvalue(:present) do
+      @resource.provider.create
+    end
+
+    newvalue(:absent) do
+      @resource.provider.destroy
+    end
+
+    defaultto(:present)
+  end
 
   newparam(:name, :namevar => :true) do
     desc "Name of the service resource in Puppet"
@@ -24,6 +34,7 @@ Puppet::Type.newtype(:firewalld_service) do
 
   newparam(:service) do
     desc "Name of the service to add"
+    defaultto { @resource[:name] }
   end
 
   newparam(:zone) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,9 @@ class firewalld (
   Boolean $purge_direct_chains       = false,
   Boolean $purge_direct_passthroughs = false,
   Optional[String] $default_zone     = undef,
+  Optional[String] $default_service_zone  = undef,
+  Optional[String] $default_port_zone     = undef,
+  Optional[String] $default_port_protocol = undef,
   Optional[Enum['off','all','unicast','broadcast','multicast']] $log_denied = undef
 ) {
 
@@ -93,6 +96,11 @@ class firewalld (
     }
 
     # create ports
+    Firewalld_port {
+      zone      => $default_port_zone,
+      protocol  => $default_port_protocol,
+    }
+
     $ports.each |String $key, Hash $attrs| {
       firewalld_port { $key:
         *       => $attrs,
@@ -107,6 +115,10 @@ class firewalld (
     }
 
     #...services
+    Firewalld_service {
+      zone      => $default_service_zone,
+    }
+
     $services.each | String $key, Hash $attrs| {
       firewalld_service { $key:
         *       => $attrs,

--- a/spec/unit/puppet/type/firewalld_port_spec.rb
+++ b/spec/unit/puppet/type/firewalld_port_spec.rb
@@ -8,7 +8,7 @@ describe Puppet::Type.type(:firewalld_port) do
 
   context 'with no params' do
     describe 'when validating attributes' do
-      [:name, :zone, :port].each do |param|
+      [:name, :zone, :port, :protocol].each do |param|
         it "should have a #{param} parameter" do
           expect(described_class.attrtype(param)).to eq(:param)
         end
@@ -18,19 +18,6 @@ describe Puppet::Type.type(:firewalld_port) do
     describe 'namevar validation' do
       it 'should have :name as its namevar' do
         expect(described_class.key_attributes).to eq([:name])
-      end
-    end
-
-    describe 'port' do
-      port = { 'port' => 8080, 'protocol' => 'tcp' }
-      it "should accept '#{port}'" do
-        expect do
-          described_class.new(
-            name: 'Allow port 8080',
-            zone: 'public',
-            port: port
-          ).to_not raise_error
-        end
       end
     end
   end


### PR DESCRIPTION
Hi Craig,

Having to specify service/port, zone and ensure for each service or port
is highly redundant and cumbersome. Make service and port default to the
resource name, ensure default to present and allow to set a default
target zone for services and ports via parameters to the firewalld
class. For ports the default protocol can also be set through a
firewalld class parameter.

Incidentally change the port spec test which seems to be incorrect
regarding parameter port accepting a hash.