### PR TITLE
Ipset options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.2.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.3.0"
+  - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.4.0"
   - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.5.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,26 @@
 language: ruby
 bundler_args: --without acceptance
 script: "bundle exec rake test SPEC_OPTS='--format documentation'"
-env:
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
-  - PUPPET_VERSION="~> 4.2.0"
-  - PUPPET_VERSION="~> 4.3.0"
-  - PUPPET_VERSION="~> 4.4.0"
-  - PUPPET_VERSION="~> 4.5.0"
-  - PUPPET_VERSION="~> 4.6.1"
-  - PUPPET_VERSION="~> 4.7.0"
-  - PUPPET_VERSION="~> 4.8.0"
-rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
+matrix:
+  fast_finish: true
+  include:
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.4.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.5.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.6.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.7.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.8.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.9.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4.10.0"
+  - rvm: 2.1.9
+    env: PUPPET_VERSION="~> 4"
+  - rvm: 2.4.1
+    env: PUPPET_VERSION="~> 5.0.0"
+  - rvm: 2.4.1
+    env: PUPPET_VERSION="~> 5"

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -74,7 +74,7 @@ Puppet::Type.newtype(:firewalld_ipset) do
     desc "Timeout in seconds before entries expiry"
   end
 
-  newproperty(:manage_entries, :parent => Puppet::Parameter::Boolean) do
+  newparam(:manage_entries, :parent => Puppet::Parameter::Boolean) do
     desc "Should we manage entries in this ipset or leave another process manage those entries"
     defaultto true
   end

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -43,6 +43,12 @@ Puppet::Type.newtype(:firewalld_ipset) do
       should.sort == is
     end
 
+
+    munge do |value|
+      value.gsub('/32', '')
+    end
+  end
+
   newproperty(:family) do
     desc "Protocol family of the IPSet"
     newvalues(:inet6, :inet)

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -43,6 +43,14 @@ Puppet::Type.newtype(:firewalld_ipset) do
       should.sort == is
     end
 
+    def change_to_s(current, desire)
+      if @resource.value(:keep_in_sync)
+        "removing entries from ipset #{(current - desire).sort.inspect},
+         adding in ipset entries #{(desire - current).sort.inspect}"
+      else
+        "adding in ipset entries #{(desire - current).sort.inspect}"
+      end
+    end
 
     munge do |value|
       value.gsub('/32', '')

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -26,6 +26,7 @@ Puppet::Type.newtype(:firewalld_ipset) do
   newparam(:type) do
     desc "Type of the ipset (default: hash:ip)"
     defaultto "hash:ip"
+    newvalues(:'bitmap:ip', :'bitmap:ip,mac', :'bitmap:port', :'hash:ip', :'hash:ip,mark', :'hash:ip,port', :'hash:ip,port,ip', :'hash:ip,port,net', :'hash:mac', :'hash:net', :'hash:net,iface', :'hash:net,net', :'hash:net,port', :'hash:net,port,net', :'list:set')
   end
 
   newparam(:options) do

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -6,11 +6,11 @@ Puppet::Type.newtype(:firewalld_ipset) do
     
     Example:
     
-        firewalld_port {'Open port 8080 in the public Zone':
+        firewalld_ipset {'internal net':
             ensure   => 'present',
-            zone     => 'public',
-            port     => 8080,
-            protocol => 'tcp',
+            type     => 'hash:net',
+            family   => 'inet',
+            entries  => ['192.168.0.0/24']
         }
   }
   

--- a/lib/puppet/type/firewalld_ipset.rb
+++ b/lib/puppet/type/firewalld_ipset.rb
@@ -1,3 +1,4 @@
+require_relative '../../puppet_x/firewalld/property/positive_integer'
 
 Puppet::Type.newtype(:firewalld_ipset) do
 
@@ -41,6 +42,22 @@ Puppet::Type.newtype(:firewalld_ipset) do
     def insync?(is)
       should.sort == is
     end
+
+  newproperty(:family) do
+    desc "Protocol family of the IPSet"
+    newvalues(:inet6, :inet)
+  end
+
+  newproperty(:hashsize, :parent => PuppetX::Firewalld::Property::PositiveInteger) do
+    desc "Initial hash size of the IPSet"
+  end
+
+  newproperty(:maxelem, :parent => PuppetX::Firewalld::Property::PositiveInteger) do
+    desc "Maximal number of elements that can be stored in the set"
+  end
+
+  newproperty(:timeout, :parent => PuppetX::Firewalld::Property::PositiveInteger) do
+    desc "Timeout in seconds before entries expiry"
   end
 
 end

--- a/lib/puppet_x/firewalld/property/positive_integer.rb
+++ b/lib/puppet_x/firewalld/property/positive_integer.rb
@@ -1,0 +1,15 @@
+module PuppetX
+  module Firewalld
+    module Property
+      class PositiveInteger < Puppet::Property
+        def insync?(is)
+          is.to_i == should.to_i
+        end
+        validate do |value|
+          raise "#{name} should be an Integer" unless value.to_i.to_s == value.to_s
+          raise "#{name} should be greater than 0" unless value.to_i > 0
+        end
+      end
+    end
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "requirements": [
    {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/unit/puppet/provider/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_ipset_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:firewalld_ipset).provider(:firewall_cmd)
+
+describe provider_class do
+  let(:resource) do
+    @resource = Puppet::Type.type(:firewalld_ipset).new(
+      ensure: :present,
+      name: 'white',
+      type: 'hash:net',
+      entries: ['8.8.8.8'],
+      provider: described_class.name
+    )
+  end
+  let(:provider) { resource.provider }
+  before :each do
+    provider.class.stubs(:execute_firewall_cmd).with(['--get-ipsets'], nil).returns('white black')
+    provider.class.stubs(:execute_firewall_cmd).with(['--state'], nil, false, false).returns(Object.any_instance.stubs(exitstatus: 0))
+    provider.class.stubs(:execute_firewall_cmd).with(['--info-ipset=white'], nil).returns('white
+  type: hash:ip
+  options: maxelem=200 family=inet6
+  entries:')
+    provider.class.stubs(:execute_firewall_cmd).with(['--info-ipset=black'], nil).returns('black
+  type: hash:ip
+  options: maxelem=400 family=inet hashsize=2048
+  entries:')
+    provider.class.stubs(:execute_firewall_cmd).with(['--ipset=white', '--get-entries'], nil).returns('')
+  end
+
+  describe 'self.instances' do
+    it 'returns an array of ip sets' do
+      ipsets_names = provider.class.instances.collect(&:name)
+      expect(ipsets_names).to include('black', 'white')
+      ipsets_families = provider.class.instances.collect(&:family)
+      expect(ipsets_families).to include('inet', 'inet6')
+      ipsets_hashsize = provider.class.instances.collect(&:hashsize)
+      expect(ipsets_hashsize).to include('2048')
+      ipsets_maxelem = provider.class.instances.collect(&:maxelem)
+      expect(ipsets_maxelem).to include('200', '400')
+    end
+  end
+
+  describe 'when creating' do
+    context 'basic ipset' do
+      it 'should create a new ipset with entries' do
+        resource.expects(:[]).with(:name).returns('white').at_least_once
+        resource.expects(:[]).with(:type).returns('hash:net').at_least_once
+        resource.expects(:[]).with(:family).returns('inet').at_least_once
+        resource.expects(:[]).with(:hashsize).returns(1024).at_least_once
+        resource.expects(:[]).with(:maxelem).returns(65_536).at_least_once
+        resource.expects(:[]).with(:timeout).returns(nil).at_least_once
+        resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:entries).returns(['192.168.0/24', '10.0.0/8'])
+        provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet', '--option=hashsize=1024', '--option=maxelem=65536'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=192.168.0/24'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=10.0.0/8'], nil)
+        provider.create
+      end
+    end
+  end
+
+  describe 'when modifying' do
+    context 'hashsize' do
+      it 'should remove and create a new ipset' do
+        resource.expects(:[]).with(:name).returns('white').at_least_once
+        resource.expects(:[]).with(:type).returns('hash:net').at_least_once
+        resource.expects(:[]).with(:family).returns('inet').at_least_once
+        resource.expects(:[]).with(:hashsize).returns(nil)
+        resource.expects(:[]).with(:hashsize).returns(2048)
+        resource.expects(:[]).with(:maxelem).returns(nil).at_least_once
+        resource.expects(:[]).with(:timeout).returns(nil).at_least_once
+        resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:entries).returns(['192.168.0/24', '10.0.0/8']).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet', '--option=hashsize=2048'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=192.168.0/24'], nil).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=10.0.0/8'], nil).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--delete-ipset=white'], nil)
+        provider.create
+        provider.hashsize = 2048
+      end
+    end
+    context 'entries' do
+      it 'should remove and add entries' do
+        resource.expects(:[]).with(:name).returns('white').at_least_once
+        resource.expects(:[]).with(:type).returns('hash:net').at_least_once
+        resource.expects(:[]).with(:family).returns('inet').at_least_once
+        resource.expects(:[]).with(:hashsize).returns(nil)
+        resource.expects(:[]).with(:maxelem).returns(nil).at_least_once
+        resource.expects(:[]).with(:timeout).returns(nil).at_least_once
+        resource.expects(:[]).with(:options).returns({}).at_least_once
+        resource.expects(:[]).with(:entries).returns(['192.168.0.0/24', '10.0.0.0/8']).at_least_once
+        provider.expects(:entries).returns(['192.168.0.0/24', '10.0.0.0/8'])
+        provider.expects(:execute_firewall_cmd).with(['--new-ipset=white', '--type=hash:net', '--option=family=inet'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=192.168.0.0/24'], nil).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=10.0.0.0/8'], nil).at_least_once
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--add-entry=192.168.14.0/24'], nil)
+        provider.expects(:execute_firewall_cmd).with(['--ipset=white', '--remove-entry=192.168.0.0/24'], nil)
+        provider.create
+        provider.entries = ['192.168.14.0/24', '10.0.0.0/8']
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -79,6 +79,18 @@ describe Puppet::Type.type(:firewalld_ipset) do
       provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--remove-entry=10.8.8.8'], nil)
       provider.entries=(['192.168.2.2', '10.72.1.100'])
     end
+  end
+  context 'change in ipset members' do
+    let(:resource) do
+      Puppet::Type.type(:firewalld_ipset).new(
+        name: 'white',
+        type: 'hash:net',
+        entries: ['8.8.8.8/32', '9.9.9.9']
+      )
+    end
 
+    it 'removes /32 in set members' do
+      expect(resource[:entries]).to eq ['8.8.8.8', '9.9.9.9']
+    end
   end
 end


### PR DESCRIPTION
Improve `firewalld_ipset` type:
  - Declare new properties
  - Improve logging of ipset member changes
  - Gather current state at once using prefetch "pattern" to avoid declaration of many getter

Add more tests