### PR TITLE
Speed up ipset entries changes

### DIFF
--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -4,6 +4,14 @@ describe Puppet::Type.type(:firewalld_ipset) do
 
   before do
     Puppet::Provider::Firewalld.any_instance.stubs(:state).returns(:true)
+    tempfile = stub('tempfile', :class => Tempfile,
+                  :write => true,
+                  :flush => true,
+                  :close! => true,
+                  :close => true,
+                  :path => '/tmp/ipset-rspec'
+                 )
+      Tempfile.stubs(:new).returns(tempfile)
   end
 
   describe "type" do
@@ -55,8 +63,7 @@ describe Puppet::Type.type(:firewalld_ipset) do
 
     it "should create" do
       provider.expects(:execute_firewall_cmd).with(['--new-ipset=whitelist', '--type=hash:ip'], nil)
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=192.168.2.2'], nil)
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=10.72.1.100'], nil)
+      provider.expects(:execute_firewall_cmd).with(["--ipset=whitelist", "--add-entries-from-file=/tmp/ipset-rspec"], nil)
       provider.create
     end
 
@@ -66,17 +73,16 @@ describe Puppet::Type.type(:firewalld_ipset) do
     end
 
     it "should set entries" do
-      provider.expects(:entries).returns([])
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=192.168.2.2'], nil)
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=10.72.1.100'], nil)
+      provider.expects(:entries).returns([]).at_least_once()
+      provider.expects(:execute_firewall_cmd).with(["--ipset=whitelist", "--add-entries-from-file=/tmp/ipset-rspec"], nil)
+      provider.expects(:execute_firewall_cmd).with(["--ipset=whitelist", "--remove-entries-from-file=/tmp/ipset-rspec"], nil)
       provider.entries=(['192.168.2.2', '10.72.1.100'])
     end
 
     it "should remove unconfigured entries" do
-      provider.expects(:entries).returns(['10.9.9.9', '10.8.8.8', '10.72.1.100'])
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=192.168.2.2'], nil)
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--remove-entry=10.9.9.9'], nil)
-      provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--remove-entry=10.8.8.8'], nil)
+      provider.expects(:entries).returns(['10.9.9.9', '10.8.8.8', '10.72.1.100']).at_least_once()
+      provider.expects(:execute_firewall_cmd).with(["--ipset=whitelist", "--add-entries-from-file=/tmp/ipset-rspec"], nil)
+      provider.expects(:execute_firewall_cmd).with(["--ipset=whitelist", "--remove-entries-from-file=/tmp/ipset-rspec"], nil)
       provider.entries=(['192.168.2.2', '10.72.1.100'])
     end
 


### PR DESCRIPTION
We now use `--add-entries-from-file` and `--remove-entries-from-file` to
change firewalld ipset. Adding or removing entries one by one was really
slow.

This pull request is based on
https://github.com/42wim/puppet-firewalld/blob/04683b46cbe6e6a925c585283941cc363752aceb/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
first pull request was here: jfroche/puppet-firewalld#4