### PR TITLE
Test won't work for Puppet 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.1.9
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 2.1.9
     env: PUPPET_VERSION="~> 4.2.0"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This module manages firewalld, the userland interface that replaces iptables and
 
 ## Compatibility
 
-Latest versions of this module (3.0+) are only supported on Puppet 4.0+.  2.2.0 is the latest version to run on Puppet 3.x, important patches (security bugs..etc) will be accepted in the 2.x until Puppet 3.x is offically end-of-life, but new features will only be accepted in 3.x.
+Latest versions of this module (3.0+) are only supported on Puppet 4.1+.  2.2.0 is the latest version to run on Puppet 3.x, important patches (security bugs..etc) will be accepted in the 2.x until Puppet 3.x is offically end-of-life, but new features will only be accepted in 3.x.
 
 ## Usage
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "requirements": [
    {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 6.0.0"
+      "version_requirement": ">= 4.1.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
As `rspec-puppet` breaks with puppet 4.0.0 (see rodjek/rspec-puppet#663),
I propose to drop tests and support for puppet 4.0.0