### PR TITLE
Pin old rspec-puppet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'puppet', puppetversion
 gem 'puppetlabs_spec_helper', '>= 0.8.2'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet', '2.6.9'
 group :acceptance do
   gem 'beaker-rspec'
   gem 'beaker'


### PR DESCRIPTION
Latest version (2.6.11) has a compatibility problem with 4.0

Avoids dropping support for 4.0 #178 