### PR TITLE
(#407) Make the module noop safe if firewalld isn't installed

### DIFF
--- a/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_custom_service/firewall_cmd.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:firewalld_custom_service).provide(
   mk_resource_methods
 
   def exists?
+    return false unless available?
+
     builtin = true
 
     found_resource = execute_firewall_cmd(['--get-services'], nil).strip.split.include?(@resource[:name])

--- a/lib/puppet/provider/firewalld_direct_chain/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_chain/firewall_cmd.rb
@@ -7,6 +7,8 @@ Puppet::Type.type(:firewalld_direct_chain).provide(:firewall_cmd, parent: Puppet
   desc 'Provider for managing firewalld direct chains using firewall-cmd'
 
   def exists?
+    return false unless available?
+
     @chain_args ||= generate_raw
     output = execute_firewall_cmd(['--direct', '--query-chain', @chain_args], nil, true, false)
     output.include?('yes')

--- a/lib/puppet/provider/firewalld_direct_passthrough/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_passthrough/firewall_cmd.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:firewalld_direct_passthrough).provide(
   desc 'Interact with firewall-cmd'
 
   def exists?
+    return false unless available?
+
     @passt_args ||= generate_raw
     output = execute_firewall_cmd(['--direct', '--query-passthrough', @passt_args], nil, true, false)
     output.include?('yes')

--- a/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_direct_rule/firewall_cmd.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:firewalld_direct_rule).provide(
   desc 'Interact with firewall-cmd'
 
   def exists?
+    return false unless available?
+
     @rule_args ||= generate_raw
     output = execute_firewall_cmd(['--direct', '--query-rule', @rule_args], nil, true, false)
     output.include?('yes')

--- a/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:firewalld_ipset).provide(
   mk_resource_methods
 
   def self.instances
+    return [] unless available?
+
     ipset_ids = execute_firewall_cmd(['--get-ipsets'], nil).split
     ipset_ids.map do |ipset_id|
       ipset_raw = execute_firewall_cmd(["--info-ipset=#{ipset_id}"], nil)

--- a/lib/puppet/provider/firewalld_policy/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_policy/firewall_cmd.rb
@@ -11,6 +11,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   desc 'Interact with firewall-cmd'
 
   def exists?
+    return false unless available?
+
     @resource[:policy] = @resource[:name]
     execute_firewall_cmd_policy(['--get-policies'], nil).split.include?(@resource[:name])
   end

--- a/lib/puppet/provider/firewalld_port/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_port/firewall_cmd.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:firewalld_port).provide(
   mk_resource_methods
 
   def exists?
+    return false unless available?
+
     @rule_args ||= build_port_rule
 
     output = if @resource[:zone] == :unset

--- a/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_rich_rule/firewall_cmd.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:firewalld_rich_rule).provide(
   mk_resource_methods
 
   def exists?
+    return false unless available?
+
     @rule_args ||= build_rich_rule
     output = if @resource[:zone] == :unset
                execute_firewall_cmd_policy(['--query-rich-rule', @rule_args],

--- a/lib/puppet/provider/firewalld_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_service/firewall_cmd.rb
@@ -32,6 +32,8 @@ Puppet::Type.type(:firewalld_service).provide(
   end
 
   def exists?
+    return false unless available?
+
     if @resource[:zone] == :unset
       execute_firewall_cmd_policy(['--list-services']).split.include?(@resource[:service])
     else

--- a/lib/puppet/provider/firewalld_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_service/firewall_cmd.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:firewalld_service).provide(
   desc 'Interact with firewall-cmd'
 
   def self.instances
+    return [] unless available?
+
     services = execute_firewall_cmd(['--get-services'], nil).split
     services.map do |service|
       new(

--- a/lib/puppet/provider/firewalld_service/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_service/firewall_cmd.rb
@@ -37,7 +37,12 @@ Puppet::Type.type(:firewalld_service).provide(
     if @resource[:zone] == :unset
       execute_firewall_cmd_policy(['--list-services']).split.include?(@resource[:service])
     else
-      execute_firewall_cmd(['--list-services']).split.include?(@resource[:service])
+      # Use failonfail: false so that a non-existent zone (e.g. during noop when
+      # the zone hasn't been created yet) returns false rather than raising an error.
+      result = execute_firewall_cmd(['--list-services'], @resource[:zone], true, false)
+      return false unless result.exitstatus.zero?
+
+      result.split.include?(@resource[:service])
     end
   end
 

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -11,6 +11,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   desc 'Interact with firewall-cmd'
 
   def exists?
+    return false unless available?
+
     @resource[:zone] = @resource[:name]
     execute_firewall_cmd(['--get-zones'], nil).split.include?(@resource[:name])
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -290,7 +290,7 @@ class firewalld (
 
     exec { 'firewalld::set_default_zone_offline':
       command => ['firewall-offline-cmd', '--set-default-zone', $default_zone],
-      onlyif  => 'which firewall-offline-cmd',
+      onlyif  => 'sh -c "command -v firewall-offline-cmd > /dev/null 2>&1"',
       unless  => [
         "[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]",
         'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
@@ -317,7 +317,7 @@ class firewalld (
     }
     exec { 'firewalld::set_log_denied_offline':
       command => ['firewall-offline-cmd', '--set-log-denied', $log_denied],
-      onlyif  => 'which firewall-offline-cmd',
+      onlyif  => 'sh -c "command -v firewall-offline-cmd > /dev/null 2>&1"',
       unless  => [
         "[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]",
         'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,14 +284,17 @@ class firewalld (
     exec { 'firewalld::set_default_zone_active':
       command => ['firewall-cmd', '--set-default-zone', $default_zone],
       unless  => "[ $(firewall-cmd --get-default-zone) = ${default_zone} ]",
-      onlyif  => 'sh -c "firewall-cmd --state"',
+      onlyif  => 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
       require => Service['firewalld'],
     }
 
     exec { 'firewalld::set_default_zone_offline':
       command => ['firewall-offline-cmd', '--set-default-zone', $default_zone],
       onlyif  => 'which firewall-offline-cmd',
-      unless  => ["[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]", 'sh -c "firewall-cmd --state"',],
+      unless  => [
+        "[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]",
+        'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
+      ],
     }
 
     Firewalld_zone <||> -> Exec['firewalld::set_default_zone']
@@ -309,13 +312,16 @@ class firewalld (
     exec { 'firewalld::set_log_denied_active':
       command => ['firewall-cmd', '--set-log-denied', $log_denied],
       unless  => "[ $(firewall-cmd --get-log-denied) = ${log_denied} ]",
-      onlyif  => 'sh -c "firewall-cmd --state"',
+      onlyif  => 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
       require => Service['firewalld'],
     }
     exec { 'firewalld::set_log_denied_offline':
       command => ['firewall-offline-cmd', '--set-log-denied', $log_denied],
       onlyif  => 'which firewall-offline-cmd',
-      unless  => ["[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]", 'sh -c "firewall-cmd --state"'],
+      unless  => [
+        "[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]",
+        'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
+      ],
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -290,6 +290,7 @@ class firewalld (
 
     exec { 'firewalld::set_default_zone_offline':
       command => ['firewall-offline-cmd', '--set-default-zone', $default_zone],
+      onlyif  => 'which firewall-offline-cmd',
       unless  => ["[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]", 'firewall-cmd --state',],
     }
 
@@ -313,6 +314,7 @@ class firewalld (
     }
     exec { 'firewalld::set_log_denied_offline':
       command => ['firewall-offline-cmd', '--set-log-denied', $log_denied],
+      onlyif  => 'which firewall-offline-cmd',
       unless  => ["[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]", 'firewall-cmd --state'],
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,14 +284,14 @@ class firewalld (
     exec { 'firewalld::set_default_zone_active':
       command => ['firewall-cmd', '--set-default-zone', $default_zone],
       unless  => "[ $(firewall-cmd --get-default-zone) = ${default_zone} ]",
-      onlyif  => 'firewall-cmd --state',
+      onlyif  => 'sh -c "firewall-cmd --state"',
       require => Service['firewalld'],
     }
 
     exec { 'firewalld::set_default_zone_offline':
       command => ['firewall-offline-cmd', '--set-default-zone', $default_zone],
       onlyif  => 'which firewall-offline-cmd',
-      unless  => ["[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]", 'firewall-cmd --state',],
+      unless  => ["[ $(firewall-offline-cmd --get-default-zone) = ${default_zone} ]", 'sh -c "firewall-cmd --state"',],
     }
 
     Firewalld_zone <||> -> Exec['firewalld::set_default_zone']
@@ -309,13 +309,13 @@ class firewalld (
     exec { 'firewalld::set_log_denied_active':
       command => ['firewall-cmd', '--set-log-denied', $log_denied],
       unless  => "[ $(firewall-cmd --get-log-denied) = ${log_denied} ]",
-      onlyif  => 'firewall-cmd --state',
+      onlyif  => 'sh -c "firewall-cmd --state"',
       require => Service['firewalld'],
     }
     exec { 'firewalld::set_log_denied_offline':
       command => ['firewall-offline-cmd', '--set-log-denied', $log_denied],
       onlyif  => 'which firewall-offline-cmd',
-      unless  => ["[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]", 'firewall-cmd --state'],
+      unless  => ["[ $(firewall-offline-cmd --get-log-denied) = ${log_denied} ]", 'sh -c "firewall-cmd --state"'],
     }
   }
 

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -43,8 +43,11 @@ describe 'firewalld noop mode without package installed', unless: UNSUPPORTED_PL
         apply_manifest_on(host, manifest, noop: true, catch_failures: true)
       end
 
-      it 'is idempotent in noop mode' do
-        apply_manifest_on(host, manifest, noop: true, catch_changes: true)
+      it 'runs repeatably in noop mode without failures' do
+        # Idempotence cannot be asserted in noop mode: Puppet always reports
+        # that it *would* make changes since nothing is ever applied. Assert
+        # that a repeat run is still failure-free instead.
+        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
       end
     end
   end

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -44,7 +44,7 @@ describe 'firewalld noop mode without package installed', unless: UNSUPPORTED_PL
       end
 
       it 'is idempotent in noop mode' do
-        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
+        apply_manifest_on(host, manifest, noop: true, catch_changes: true)
       end
     end
   end

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -42,14 +42,6 @@ describe 'firewalld noop mode without package installed', unless: UNSUPPORTED_PL
       it 'runs successfully in noop mode when the package is not installed' do
         apply_manifest_on(host, manifest, noop: true, catch_failures: true)
       end
-
-      it 'runs repeatably in noop mode without failures' do
-        # Idempotence cannot be asserted in noop mode: Puppet always reports
-        # that it *would* make changes since nothing is ever applied. Assert
-        # that repeated runs are still failure-free instead.
-        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
-        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
-      end
     end
   end
 end

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+UNSUPPORTED_PLATFORMS = %w[windows Darwin].freeze
+
+describe 'firewalld noop mode without package installed', unless: UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  hosts.each do |host|
+    context "on #{host}" do
+      before(:all) do
+        # Ensure the firewalld package is absent so we can test noop behaviour
+        # when the package has not yet been installed.
+        on(host, 'puppet resource package firewalld ensure=absent --logdest syslog', acceptable_exit_codes: [0, 1, 2])
+      end
+
+      let(:manifest) do
+        <<-EOM
+          class { 'firewalld':
+            default_zone => 'public',
+            log_denied   => 'all',
+          }
+
+          firewalld_zone { 'public':
+            ensure => 'present',
+            target => 'default',
+          }
+
+          firewalld_service { 'ssh':
+            ensure => 'present',
+            zone   => 'public',
+          }
+
+          firewalld_port { '8080/tcp':
+            ensure   => 'present',
+            port     => '8080',
+            protocol => 'tcp',
+            zone     => 'public',
+          }
+        EOM
+      end
+
+      it 'runs successfully in noop mode when the package is not installed' do
+        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
+      end
+
+      it 'is idempotent in noop mode' do
+        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
+      end
+    end
+  end
+end

--- a/spec/acceptance/noop_spec.rb
+++ b/spec/acceptance/noop_spec.rb
@@ -46,7 +46,8 @@ describe 'firewalld noop mode without package installed', unless: UNSUPPORTED_PL
       it 'runs repeatably in noop mode without failures' do
         # Idempotence cannot be asserted in noop mode: Puppet always reports
         # that it *would* make changes since nothing is ever applied. Assert
-        # that a repeat run is still failure-free instead.
+        # that repeated runs are still failure-free instead.
+        apply_manifest_on(host, manifest, noop: true, catch_failures: true)
         apply_manifest_on(host, manifest, noop: true, catch_failures: true)
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,7 +61,7 @@ describe 'firewalld' do
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'restricted'],
-        onlyif: 'which firewall-offline-cmd',
+        onlyif: 'sh -c "command -v firewall-offline-cmd > /dev/null 2>&1"',
         unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
       )
     end
@@ -268,7 +268,7 @@ describe 'firewalld' do
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'public'],
-        onlyif: 'which firewall-offline-cmd',
+        onlyif: 'sh -c "command -v firewall-offline-cmd > /dev/null 2>&1"',
         unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
       )
     end
@@ -291,7 +291,7 @@ describe 'firewalld' do
         ).that_requires('Service[firewalld]')
         is_expected.to contain_exec('firewalld::set_log_denied_offline').with(
           command: ['firewall-offline-cmd', '--set-log-denied', cond],
-          onlyif: 'which firewall-offline-cmd',
+          onlyif: 'sh -c "command -v firewall-offline-cmd > /dev/null 2>&1"',
           unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
         )
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,12 +57,12 @@ describe 'firewalld' do
       is_expected.to contain_exec('firewalld::set_default_zone_active').with(
         command: ['firewall-cmd', '--set-default-zone', 'restricted'],
         unless: '[ $(firewall-cmd --get-default-zone) = restricted ]',
-        onlyif: 'sh -c "firewall-cmd --state"',
+        onlyif: 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'restricted'],
         onlyif: 'which firewall-offline-cmd',
-        unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'sh -c "firewall-cmd --state"'],
+        unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
       )
     end
   end
@@ -264,12 +264,12 @@ describe 'firewalld' do
       is_expected.to contain_exec('firewalld::set_default_zone_active').with(
         command: ['firewall-cmd', '--set-default-zone', 'public'],
         unless: '[ $(firewall-cmd --get-default-zone) = public ]',
-        onlyif: 'sh -c "firewall-cmd --state"',
+        onlyif: 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'public'],
         onlyif: 'which firewall-offline-cmd',
-        unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'sh -c "firewall-cmd --state"'],
+        unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
       )
     end
   end
@@ -287,12 +287,12 @@ describe 'firewalld' do
         is_expected.to contain_exec('firewalld::set_log_denied_active').with(
           command: ['firewall-cmd', '--set-log-denied', cond],
           unless: "[ $(firewall-cmd --get-log-denied) = #{cond} ]",
-          onlyif: 'sh -c "firewall-cmd --state"',
+          onlyif: 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"',
         ).that_requires('Service[firewalld]')
         is_expected.to contain_exec('firewalld::set_log_denied_offline').with(
           command: ['firewall-offline-cmd', '--set-log-denied', cond],
           onlyif: 'which firewall-offline-cmd',
-          unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'sh -c "firewall-cmd --state"'],
+          unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'sh -c "command -v firewall-cmd > /dev/null 2>&1 && firewall-cmd --state"'],
         )
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -57,12 +57,12 @@ describe 'firewalld' do
       is_expected.to contain_exec('firewalld::set_default_zone_active').with(
         command: ['firewall-cmd', '--set-default-zone', 'restricted'],
         unless: '[ $(firewall-cmd --get-default-zone) = restricted ]',
-        onlyif: 'firewall-cmd --state',
+        onlyif: 'sh -c "firewall-cmd --state"',
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'restricted'],
         onlyif: 'which firewall-offline-cmd',
-        unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'firewall-cmd --state'],
+        unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'sh -c "firewall-cmd --state"'],
       )
     end
   end
@@ -264,12 +264,12 @@ describe 'firewalld' do
       is_expected.to contain_exec('firewalld::set_default_zone_active').with(
         command: ['firewall-cmd', '--set-default-zone', 'public'],
         unless: '[ $(firewall-cmd --get-default-zone) = public ]',
-        onlyif: 'firewall-cmd --state',
+        onlyif: 'sh -c "firewall-cmd --state"',
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'public'],
         onlyif: 'which firewall-offline-cmd',
-        unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'firewall-cmd --state'],
+        unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'sh -c "firewall-cmd --state"'],
       )
     end
   end
@@ -287,12 +287,12 @@ describe 'firewalld' do
         is_expected.to contain_exec('firewalld::set_log_denied_active').with(
           command: ['firewall-cmd', '--set-log-denied', cond],
           unless: "[ $(firewall-cmd --get-log-denied) = #{cond} ]",
-          onlyif: 'firewall-cmd --state',
+          onlyif: 'sh -c "firewall-cmd --state"',
         ).that_requires('Service[firewalld]')
         is_expected.to contain_exec('firewalld::set_log_denied_offline').with(
           command: ['firewall-offline-cmd', '--set-log-denied', cond],
           onlyif: 'which firewall-offline-cmd',
-          unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'firewall-cmd --state'],
+          unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'sh -c "firewall-cmd --state"'],
         )
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -61,6 +61,7 @@ describe 'firewalld' do
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'restricted'],
+        onlyif: 'which firewall-offline-cmd',
         unless: ['[ $(firewall-offline-cmd --get-default-zone) = restricted ]', 'firewall-cmd --state'],
       )
     end
@@ -267,6 +268,7 @@ describe 'firewalld' do
       ).that_requires('Service[firewalld]')
       is_expected.to contain_exec('firewalld::set_default_zone_offline').with(
         command: ['firewall-offline-cmd', '--set-default-zone', 'public'],
+        onlyif: 'which firewall-offline-cmd',
         unless: ['[ $(firewall-offline-cmd --get-default-zone) = public ]', 'firewall-cmd --state'],
       )
     end
@@ -289,6 +291,7 @@ describe 'firewalld' do
         ).that_requires('Service[firewalld]')
         is_expected.to contain_exec('firewalld::set_log_denied_offline').with(
           command: ['firewall-offline-cmd', '--set-log-denied', cond],
+          onlyif: 'which firewall-offline-cmd',
           unless: ["[ $(firewall-offline-cmd --get-log-denied) = #{cond} ]", 'firewall-cmd --state'],
         )
       end

--- a/spec/unit/puppet/provider/firewalld_custom_service_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_custom_service_spec.rb
@@ -9,6 +9,7 @@ describe provider_class do
   include REXML
 
   before do
+    allow_any_instance_of(provider_class).to receive(:available?).and_return(true)
     allow_any_instance_of(provider_class).to receive(:execute_firewall_cmd).and_return(double(exitstatus: 0))
   end
 

--- a/spec/unit/puppet/provider/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_ipset_spec.rb
@@ -17,6 +17,7 @@ describe provider_class do
   let(:provider) { resource.provider }
 
   before do
+    allow(provider_class).to receive(:available?).and_return(true)
     allow(provider_class).to receive(:execute_firewall_cmd).with(['--get-ipsets'], nil).and_return('white black')
     allow(provider_class).to receive(:execute_firewall_cmd).with(['--state'], nil, false, false, false).and_return(double(exitstatus: 0))
     allow(provider_class).to receive(:execute_firewall_cmd).with(['--info-ipset=white'], nil).and_return(<<~DATA.chomp)

--- a/spec/unit/puppet/provider/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_ipset_spec.rb
@@ -35,6 +35,17 @@ describe provider_class do
   end
 
   describe 'self.instances' do
+    context 'when firewalld is not available' do
+      before do
+        allow(provider_class).to receive(:available?).and_return(false)
+      end
+
+      it 'returns an empty array without calling firewall-cmd' do
+        expect(provider_class).not_to receive(:execute_firewall_cmd)
+        expect(provider_class.instances).to eq([])
+      end
+    end
+
     describe 'returns an array of ip sets' do
       it 'with correct names' do
         ipsets_names = provider.class.instances.map(&:name)

--- a/spec/unit/puppet/provider/firewalld_service_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_service_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:firewalld_service).provider(:firewall_cmd)
+
+describe provider_class do
+  let(:resource) do
+    @resource = Puppet::Type.type(:firewalld_service).new(
+      ensure: :present,
+      name: 'ssh',
+      zone: 'public',
+      provider: described_class.name,
+    )
+  end
+  let(:provider) { resource.provider }
+
+  before do
+    allow(provider_class).to receive(:execute_firewall_cmd).with(['--state'], nil, nil, false, false, false).and_return(double(exitstatus: 0))
+    allow(provider_class).to receive(:execute_firewall_cmd).with(['--get-services'], nil).and_return('ssh http https')
+  end
+
+  describe 'self.instances' do
+    context 'when firewalld is not available' do
+      before do
+        allow(provider_class).to receive(:available?).and_return(false)
+      end
+
+      it 'returns an empty array without calling firewall-cmd' do
+        expect(provider_class).not_to receive(:execute_firewall_cmd).with(['--get-services'], nil)
+        expect(provider_class.instances).to eq([])
+      end
+    end
+
+    context 'when firewalld is available' do
+      before do
+        allow(provider_class).to receive(:available?).and_return(true)
+      end
+
+      it 'returns instances for each available service' do
+        instances = provider_class.instances
+        expect(instances.map(&:name)).to include('ssh', 'http', 'https')
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/provider/firewalld_service_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_service_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::Type.type(:firewalld_service).provider(:firewall_cmd) do
         before do
           allow(provider).to receive(:execute_firewall_cmd)
             .with(['--list-services'], 'public', true, false)
-            .and_return(double(exitstatus: 0, split: ['ssh', 'http', 'https']))
+            .and_return(double(exitstatus: 0, split: %w[ssh http https]))
         end
 
         it 'returns true' do
@@ -75,7 +75,7 @@ describe Puppet::Type.type(:firewalld_service).provider(:firewall_cmd) do
         before do
           allow(provider).to receive(:execute_firewall_cmd)
             .with(['--list-services'], 'public', true, false)
-            .and_return(double(exitstatus: 0, split: ['http', 'https']))
+            .and_return(double(exitstatus: 0, split: %w[http https]))
         end
 
         it 'returns false' do

--- a/spec/unit/puppet/provider/firewalld_service_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_service_spec.rb
@@ -41,4 +41,63 @@ describe Puppet::Type.type(:firewalld_service).provider(:firewall_cmd) do
       end
     end
   end
+
+  describe '#exists?' do
+    context 'when firewalld is not available' do
+      before do
+        allow(provider).to receive(:available?).and_return(false)
+      end
+
+      it 'returns false without calling firewall-cmd' do
+        expect(provider).not_to receive(:execute_firewall_cmd)
+        expect(provider.exists?).to be false
+      end
+    end
+
+    context 'when a zone is set' do
+      before do
+        allow(provider).to receive(:available?).and_return(true)
+      end
+
+      context 'and the zone exists with the service present' do
+        before do
+          allow(provider).to receive(:execute_firewall_cmd)
+            .with(['--list-services'], 'public', true, false)
+            .and_return(double(exitstatus: 0, split: ['ssh', 'http', 'https']))
+        end
+
+        it 'returns true' do
+          expect(provider.exists?).to be true
+        end
+      end
+
+      context 'and the zone exists but the service is absent' do
+        before do
+          allow(provider).to receive(:execute_firewall_cmd)
+            .with(['--list-services'], 'public', true, false)
+            .and_return(double(exitstatus: 0, split: ['http', 'https']))
+        end
+
+        it 'returns false' do
+          expect(provider.exists?).to be false
+        end
+      end
+
+      context 'and the zone does not exist (e.g. during noop when zone is being created)' do
+        before do
+          allow(provider).to receive(:execute_firewall_cmd)
+            .with(['--list-services'], 'public', true, false)
+            .and_return(double(exitstatus: 2))
+        end
+
+        it 'returns false without raising an error' do
+          expect { provider.exists? }.not_to raise_error
+        end
+
+        it 'returns false' do
+          expect(provider.exists?).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/unit/puppet/provider/firewalld_service_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_service_spec.rb
@@ -2,9 +2,7 @@
 
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:firewalld_service).provider(:firewall_cmd)
-
-describe provider_class do
+describe Puppet::Type.type(:firewalld_service).provider(:firewall_cmd) do
   let(:resource) do
     @resource = Puppet::Type.type(:firewalld_service).new(
       ensure: :present,
@@ -16,29 +14,29 @@ describe provider_class do
   let(:provider) { resource.provider }
 
   before do
-    allow(provider_class).to receive(:execute_firewall_cmd).with(['--state'], nil, nil, false, false, false).and_return(double(exitstatus: 0))
-    allow(provider_class).to receive(:execute_firewall_cmd).with(['--get-services'], nil).and_return('ssh http https')
+    allow(described_class).to receive(:execute_firewall_cmd).with(['--state'], nil, nil, false, false, false).and_return(double(exitstatus: 0))
+    allow(described_class).to receive(:execute_firewall_cmd).with(['--get-services'], nil).and_return('ssh http https')
   end
 
   describe 'self.instances' do
     context 'when firewalld is not available' do
       before do
-        allow(provider_class).to receive(:available?).and_return(false)
+        allow(described_class).to receive(:available?).and_return(false)
       end
 
       it 'returns an empty array without calling firewall-cmd' do
-        expect(provider_class).not_to receive(:execute_firewall_cmd).with(['--get-services'], nil)
-        expect(provider_class.instances).to eq([])
+        expect(described_class).not_to receive(:execute_firewall_cmd).with(['--get-services'], nil)
+        expect(described_class.instances).to eq([])
       end
     end
 
     context 'when firewalld is available' do
       before do
-        allow(provider_class).to receive(:available?).and_return(true)
+        allow(described_class).to receive(:available?).and_return(true)
       end
 
       it 'returns instances for each available service' do
-        instances = provider_class.instances
+        instances = described_class.instances
         expect(instances.map(&:name)).to include('ssh', 'http', 'https')
       end
     end

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -21,6 +21,17 @@ describe provider_class do
     allow(provider).to receive(:execute_firewall_cmd).with(['--list-interfaces']).and_return(double(exitstatus: 0, chomp: ''))
   end
 
+  describe 'when firewalld is not available' do
+    before do
+      allow(provider).to receive(:available?).and_return(false)
+    end
+
+    it 'exists? returns false without calling firewall-cmd' do
+      expect(provider).not_to receive(:execute_firewall_cmd)
+      expect(provider.exists?).to be false
+    end
+  end
+
   describe 'when creating' do
     context 'with name white' do
       it 'executes firewall_cmd with new-zone' do

--- a/spec/unit/puppet/type/firewalld_policy_spec.rb
+++ b/spec/unit/puppet/type/firewalld_policy_spec.rb
@@ -138,8 +138,7 @@ describe Puppet::Type.type(:firewalld_policy) do
       end
 
       before do
-        allow(provider).to receive(:state).and_return(true)
-        allow(provider).to receive(:available?).and_return(true)
+        allow(provider).to receive_messages(state: true, available?: true)
       end
 
       it 'checks if it exists' do
@@ -223,8 +222,7 @@ describe Puppet::Type.type(:firewalld_policy) do
       end
 
       before do
-        allow(provider).to receive(:state).and_return(true)
-        allow(provider).to receive(:available?).and_return(true)
+        allow(provider).to receive_messages(state: true, available?: true)
       end
 
       it 'sets masquerading' do

--- a/spec/unit/puppet/type/firewalld_policy_spec.rb
+++ b/spec/unit/puppet/type/firewalld_policy_spec.rb
@@ -139,6 +139,7 @@ describe Puppet::Type.type(:firewalld_policy) do
 
       before do
         allow(provider).to receive(:state).and_return(true)
+        allow(provider).to receive(:available?).and_return(true)
       end
 
       it 'checks if it exists' do
@@ -223,6 +224,7 @@ describe Puppet::Type.type(:firewalld_policy) do
 
       before do
         allow(provider).to receive(:state).and_return(true)
+        allow(provider).to receive(:available?).and_return(true)
       end
 
       it 'sets masquerading' do

--- a/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
+++ b/spec/unit/puppet/type/firewalld_rich_rule_spec.rb
@@ -7,6 +7,7 @@ RSpec.configure { |c| c.mock_with :rspec }
 describe Puppet::Type.type(:firewalld_rich_rule) do
   before do
     allow_any_instance_of(Puppet::Provider::Firewalld).to receive(:state).and_return(true)
+    allow_any_instance_of(Puppet::Provider::Firewalld).to receive(:available?).and_return(true)
   end
 
   context 'with no params' do

--- a/spec/unit/puppet/type/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/type/firewalld_zone_spec.rb
@@ -7,6 +7,7 @@ RSpec.configure { |c| c.mock_with :rspec }
 describe Puppet::Type.type(:firewalld_zone) do
   before do
     allow_any_instance_of(Puppet::Provider::Firewalld).to receive(:state).and_return(true)
+    allow_any_instance_of(Puppet::Provider::Firewalld).to receive(:available?).and_return(true)
   end
 
   let(:icmptypes) do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Make the module noop safe if firewalld-cmd isn't available (firewalld package isn't installed)

#### This Pull Request (PR) fixes the following issues
Fixes #407
