### PR TITLE
Bulk fetch and cache

### DIFF
--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -11,6 +11,86 @@ class Puppet::Provider::Firewalld < Puppet::Provider
     attr_accessor :running, :runstate
   end
 
+  # Transaction-scoped cache shared by provider subclasses that perform
+  # bulk introspection (e.g. `firewall-cmd --list-all-zones`). The cache
+  # is intentionally class-level so that getters invoked after prefetch
+  # can find the parsed data without re-shelling.
+  #
+  # Invalidated on reload_firewall (see below) and explicitly from specs
+  # via invalidate_cache!.
+  def self.catalog_cache
+    @catalog_cache ||= {}
+  end
+
+  def self.invalidate_cache!(key = nil)
+    if key.nil?
+      @catalog_cache = {}
+    elsif @catalog_cache
+      @catalog_cache.delete(key)
+    end
+  end
+
+  # Parse the output of `firewall-cmd --list-all-zones` or
+  # `firewall-cmd --list-all-policies`. Both commands emit the same
+  # block-style format:
+  #
+  #   <name> (active)
+  #     target: default
+  #     icmp-block-inversion: no
+  #     interfaces: eth0 eth1
+  #     sources:
+  #     services: ssh dhcpv6-client
+  #     ...
+  #
+  # Returns a Hash keyed by zone/policy name whose values are Hashes of
+  # `property => parsed_value`. The parser is intentionally permissive:
+  # unknown keys are retained (as strings) and missing keys are simply
+  # absent from the inner Hash, letting callers fall back to per-property
+  # queries when needed.
+  def self.parse_list_all_output(text)
+    result = {}
+    return result if text.nil? || text.empty?
+
+    current_name = nil
+    current = nil
+    current_list_key = nil
+
+    text.each_line do |line|
+      line = line.chomp
+      next if line.empty?
+
+      # Top-level entries start at column 0 and contain the name
+      # optionally followed by " (active)" or " (default)".
+      if line =~ %r{\A(\S+)(?:\s+\([^)]+\))?\s*\z}
+        current_name = Regexp.last_match(1)
+        current = {}
+        result[current_name] = current
+        current_list_key = nil
+        next
+      end
+
+      next if current.nil?
+
+      # Continuation lines for list-valued keys start with a tab or
+      # multiple spaces and have no "key:" prefix. firewalld uses this
+      # format for `rich rules:` where each rule is on its own line.
+      if line =~ %r{\A\s+(\S.*)\z} && line !~ %r{\A\s+[\w-]+:\s*(?:.*)\z}
+        (current[current_list_key] ||= []) << Regexp.last_match(1).strip if current_list_key
+        next
+      end
+
+      # Standard "  key: value" line.
+      next unless line =~ %r{\A\s+([\w-]+):\s*(.*)\z}
+
+      key = Regexp.last_match(1)
+      value = Regexp.last_match(2)
+      current_list_key = key
+      current[key] = value
+    end
+
+    result
+  end
+
   def state
     self.class.state
   end
@@ -94,7 +174,13 @@ class Puppet::Provider::Firewalld < Puppet::Provider
   # (eg: services) so the provider needs an an-hoc way of doing this since we can't
   # do it from the puppet level by notifying the service.
   def reload_firewall
-    execute_firewall_cmd(['--reload'], nil, false) if online?
+    return unless online?
+
+    execute_firewall_cmd(['--reload'], nil, false)
+    # Any bulk-prefetched state captured before the reload may no longer
+    # reflect on-disk state, so drop it and force subsequent resources to
+    # re-read authoritatively.
+    Puppet::Provider::Firewalld.invalidate_cache!
   end
 
   def offline?

--- a/lib/puppet/provider/firewalld.rb
+++ b/lib/puppet/provider/firewalld.rb
@@ -71,21 +71,31 @@ class Puppet::Provider::Firewalld < Puppet::Provider
 
       next if current.nil?
 
-      # Continuation lines for list-valued keys start with a tab or
-      # multiple spaces and have no "key:" prefix. firewalld uses this
-      # format for `rich rules:` where each rule is on its own line.
-      if line =~ %r{\A\s+(\S.*)\z} && line !~ %r{\A\s+[\w-]+:\s*(?:.*)\z}
-        (current[current_list_key] ||= []) << Regexp.last_match(1).strip if current_list_key
+      # Standard "  key: value" line.
+      if line =~ %r{\A\s+([\w-]+):\s*(.*)\z}
+        key = Regexp.last_match(1)
+        value = Regexp.last_match(2)
+        current_list_key = key
+        current[key] = value
         next
       end
 
-      # Standard "  key: value" line.
-      next unless line =~ %r{\A\s+([\w-]+):\s*(.*)\z}
+      # Continuation lines for list-valued keys start with indentation
+      # and have no "key:" prefix. firewalld uses this format for
+      # `rich rules:` where each rule is on its own line.
+      next unless line =~ %r{\A\s+(\S.*)\z}
 
-      key = Regexp.last_match(1)
-      value = Regexp.last_match(2)
-      current_list_key = key
-      current[key] = value
+      continuation = Regexp.last_match(1).strip
+      next unless current_list_key
+
+      prev = current[current_list_key]
+      if prev.is_a?(Array)
+        prev << continuation
+      elsif prev.nil? || prev.to_s.strip.empty?
+        current[current_list_key] = [continuation]
+      else
+        current[current_list_key] = [prev.to_s.strip, continuation]
+      end
     end
 
     result

--- a/lib/puppet/provider/firewalld_policy/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_policy/firewall_cmd.rb
@@ -10,8 +10,55 @@ Puppet::Type.type(:firewalld_policy).provide(
 ) do
   desc 'Interact with firewall-cmd'
 
+  # Bulk-load all policy state in a single
+  # `firewall-cmd --list-all-policies` invocation. Results are cached on
+  # Puppet::Provider::Firewalld and invalidated by reload_firewall.
+  def self.prefetched_policies
+    Puppet::Provider::Firewalld.catalog_cache[:policies] ||= begin
+      raw = execute_firewall_cmd(['--list-all-policies'], nil, nil)
+      text = raw.respond_to?(:to_str) ? raw.to_str : raw.to_s
+      Puppet::Provider::Firewalld.parse_list_all_output(text)
+    end
+  end
+
+  def self.property_hash_from_parsed(name, parsed)
+    hash = { ensure: :present, name: name }
+    hash[:target]        = parsed['target'] if parsed.key?('target')
+    hash[:ingress_zones] = parsed['ingress-zones'].to_s.split if parsed.key?('ingress-zones')
+    hash[:egress_zones]  = parsed['egress-zones'].to_s.split  if parsed.key?('egress-zones')
+    hash[:priority]      = parsed['priority'].to_s.strip      if parsed.key?('priority')
+    if parsed.key?('masquerade')
+      hash[:masquerade] = (parsed['masquerade'].to_s.strip == 'yes') ? :true : :false
+    end
+    hash[:icmp_blocks]   = parsed['icmp-blocks'].to_s.split.sort if parsed.key?('icmp-blocks')
+    hash[:description]   = parsed['description'] if parsed.key?('description')
+    hash[:short]         = parsed['short']       if parsed.key?('short')
+    hash
+  end
+
+  def self.instances
+    prefetched_policies.map do |name, parsed|
+      new(property_hash_from_parsed(name, parsed))
+    end
+  end
+
+  def self.prefetch(resources)
+    policies = prefetched_policies
+    resources.each do |name, resource|
+      next unless policies.key?(name)
+
+      resource.provider = new(property_hash_from_parsed(name, policies[name]))
+    end
+  end
+
+  def prefetched?
+    !@property_hash.nil? && !@property_hash.empty?
+  end
+
   def exists?
     @resource[:policy] = @resource[:name]
+    return @property_hash[:ensure] == :present if prefetched?
+
     execute_firewall_cmd_policy(['--get-policies'], nil).split.include?(@resource[:name])
   end
 
@@ -26,15 +73,24 @@ Puppet::Type.type(:firewalld_policy).provide(
     self.icmp_blocks = (@resource[:icmp_blocks]) if @resource[:icmp_blocks]
     self.description = (@resource[:description]) if @resource[:description]
     self.short = (@resource[:short]) if @resource[:short]
+
+    Puppet::Provider::Firewalld.invalidate_cache!(:policies)
+    @property_hash[:ensure] = :present
   end
 
   def destroy
     debug("Deleting policy #{@resource[:name]}")
     execute_firewall_cmd_policy(['--delete-policy', @resource[:name]], nil)
+    Puppet::Provider::Firewalld.invalidate_cache!(:policies)
+    @property_hash[:ensure] = :absent
   end
 
   def target
-    policy_target = execute_firewall_cmd_policy(['--get-target']).chomp
+    policy_target = if prefetched? && @property_hash.key?(:target)
+                      @property_hash[:target]
+                    else
+                      execute_firewall_cmd_policy(['--get-target']).chomp
+                    end
     # The firewall-cmd may or may not return the target surrounded by
     # %% depending on the version. See:
     # https://github.com/crayfishx/puppet-firewalld/issues/111
@@ -49,6 +105,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def ingress_zones
+    return @property_hash[:ingress_zones] || [] if prefetched? && @property_hash.key?(:ingress_zones)
+
     execute_firewall_cmd_policy(['--list-ingress-zones']).chomp.split || []
   end
 
@@ -69,6 +127,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def egress_zones
+    return @property_hash[:egress_zones] || [] if prefetched? && @property_hash.key?(:egress_zones)
+
     execute_firewall_cmd_policy(['--list-egress-zones']).chomp.split || []
   end
 
@@ -89,6 +149,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def priority
+    return @property_hash[:priority] if prefetched? && @property_hash.key?(:priority)
+
     execute_firewall_cmd_policy(['--get-priority']).chomp
   end
 
@@ -97,6 +159,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def masquerade
+    return @property_hash[:masquerade] if prefetched? && @property_hash.key?(:masquerade)
+
     if execute_firewall_cmd_policy(['--query-masquerade'], @resource[:name], true, false).chomp == 'yes'
       :true
     else
@@ -114,6 +178,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def icmp_blocks
+    return @property_hash[:icmp_blocks] || [] if prefetched? && @property_hash.key?(:icmp_blocks)
+
     get_icmp_blocks
   end
 
@@ -204,6 +270,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   # rubocop:enable Style/AccessorMethodName
 
   def description
+    return @property_hash[:description] if prefetched? && @property_hash.key?(:description)
+
     execute_firewall_cmd_policy(['--get-description'], @resource[:name], true, false)
   end
 
@@ -212,6 +280,8 @@ Puppet::Type.type(:firewalld_policy).provide(
   end
 
   def short
+    return @property_hash[:short] if prefetched? && @property_hash.key?(:short)
+
     execute_firewall_cmd_policy(['--get-short'], @resource[:name], true, false)
   end
 

--- a/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_zone/firewall_cmd.rb
@@ -10,8 +10,65 @@ Puppet::Type.type(:firewalld_zone).provide(
 ) do
   desc 'Interact with firewall-cmd'
 
+  # Bulk-load all zone state in a single `firewall-cmd --list-all-zones`
+  # invocation. The parsed result is cached on Puppet::Provider::Firewalld
+  # so that subsequent resources processed in the same Puppet transaction
+  # do not re-shell. reload_firewall invalidates this cache.
+  def self.prefetched_zones
+    Puppet::Provider::Firewalld.catalog_cache[:zones] ||= begin
+      raw = execute_firewall_cmd(['--list-all-zones'], nil)
+      text = raw.respond_to?(:to_str) ? raw.to_str : raw.to_s
+      Puppet::Provider::Firewalld.parse_list_all_output(text)
+    end
+  end
+
+  # Translate a single parsed zone Hash (from parse_list_all_output) into
+  # a @property_hash suitable for seeding a provider instance.
+  def self.property_hash_from_parsed(name, parsed)
+    hash = { ensure: :present, name: name }
+    hash[:target] = parsed['target'] if parsed.key?('target')
+    hash[:interfaces] = parsed['interfaces'].to_s.split if parsed.key?('interfaces')
+    hash[:sources]    = parsed['sources'].to_s.split.sort if parsed.key?('sources')
+    hash[:protocols]  = parsed['protocols'].to_s.split.sort if parsed.key?('protocols')
+    if parsed.key?('masquerade')
+      hash[:masquerade] = (parsed['masquerade'].to_s.strip == 'yes') ? :true : :false
+    end
+    if parsed.key?('icmp-block-inversion')
+      hash[:icmp_block_inversion] = (parsed['icmp-block-inversion'].to_s.strip == 'yes') ? :true : :false
+    end
+    hash[:icmp_blocks] = parsed['icmp-blocks'].to_s.split.sort if parsed.key?('icmp-blocks')
+    hash[:description] = parsed['description'] if parsed.key?('description')
+    hash[:short]       = parsed['short']       if parsed.key?('short')
+    hash
+  end
+
+  def self.instances
+    prefetched_zones.map do |name, parsed|
+      new(property_hash_from_parsed(name, parsed))
+    end
+  end
+
+  def self.prefetch(resources)
+    zones = prefetched_zones
+    resources.each do |name, resource|
+      next unless zones.key?(name)
+
+      resource.provider = new(property_hash_from_parsed(name, zones[name]))
+    end
+  end
+
+  # Was this provider instance seeded from a bulk prefetch?  Used by
+  # getters to decide whether to trust @property_hash or fall back to a
+  # per-property shell-out (the latter is needed when a zone was created
+  # mid-run, after prefetch).
+  def prefetched?
+    !@property_hash.nil? && !@property_hash.empty?
+  end
+
   def exists?
     @resource[:zone] = @resource[:name]
+    return @property_hash[:ensure] == :present if prefetched?
+
     execute_firewall_cmd(['--get-zones'], nil).split.include?(@resource[:name])
   end
 
@@ -27,15 +84,26 @@ Puppet::Type.type(:firewalld_zone).provide(
     self.icmp_block_inversion = (@resource[:icmp_block_inversion]) if @resource[:icmp_block_inversion]
     self.description = (@resource[:description]) if @resource[:description]
     self.short = (@resource[:short]) if @resource[:short]
+
+    # Newly-created zones invalidate the bulk cache so that downstream
+    # resources (e.g. another zone in the same run) see consistent state.
+    Puppet::Provider::Firewalld.invalidate_cache!(:zones)
+    @property_hash[:ensure] = :present
   end
 
   def destroy
     debug("Deleting zone #{@resource[:name]}")
     execute_firewall_cmd(['--delete-zone', @resource[:name]], nil)
+    Puppet::Provider::Firewalld.invalidate_cache!(:zones)
+    @property_hash[:ensure] = :absent
   end
 
   def target
-    zone_target = execute_firewall_cmd(['--get-target']).chomp
+    zone_target = if prefetched? && @property_hash.key?(:target)
+                    @property_hash[:target]
+                  else
+                    execute_firewall_cmd(['--get-target']).chomp
+                  end
     # The firewall-cmd may or may not return the target surrounded by
     # %% depending on the version. See:
     # https://github.com/crayfishx/puppet-firewalld/issues/111
@@ -50,6 +118,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def interfaces
+    return @property_hash[:interfaces] || [] if prefetched? && @property_hash.key?(:interfaces)
+
     execute_firewall_cmd(['--list-interfaces']).chomp.split || []
   end
 
@@ -67,6 +137,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def sources
+    return @property_hash[:sources] || [] if prefetched? && @property_hash.key?(:sources)
+
     execute_firewall_cmd(['--list-sources']).chomp.split.sort || []
   end
 
@@ -84,6 +156,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def protocols
+    return @property_hash[:protocols] || [] if prefetched? && @property_hash.key?(:protocols)
+
     execute_firewall_cmd(['--list-protocols']).chomp.split.sort || []
   end
 
@@ -101,6 +175,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def masquerade
+    return @property_hash[:masquerade] if prefetched? && @property_hash.key?(:masquerade)
+
     if execute_firewall_cmd(['--query-masquerade'], @resource[:name], true, false).chomp == 'yes'
       :true
     else
@@ -118,6 +194,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def icmp_blocks
+    return @property_hash[:icmp_blocks] || [] if prefetched? && @property_hash.key?(:icmp_blocks)
+
     get_icmp_blocks
   end
 
@@ -145,6 +223,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def icmp_block_inversion
+    return @property_hash[:icmp_block_inversion] if prefetched? && @property_hash.key?(:icmp_block_inversion)
+
     if execute_firewall_cmd(['--query-icmp-block-inversion'], @resource[:name], true, false).chomp == 'yes'
       :true
     else
@@ -197,6 +277,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   # rubocop:enable Naming/AccessorMethodName
 
   def description
+    return @property_hash[:description] if prefetched? && @property_hash.key?(:description)
+
     execute_firewall_cmd(['--get-description'], @resource[:name], true, false)
   end
 
@@ -205,6 +287,8 @@ Puppet::Type.type(:firewalld_zone).provide(
   end
 
   def short
+    return @property_hash[:short] if prefetched? && @property_hash.key?(:short)
+
     execute_firewall_cmd(['--get-short'], @resource[:name], true, false)
   end
 

--- a/spec/unit/puppet/provider/firewalld_policy_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_policy_spec.rb
@@ -127,16 +127,16 @@ describe provider_class do
     end
 
     it 'serves a second prefetched_policies call from the cache' do
+      expect(described_class).to receive(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).once.and_return(list_all_policies_output)
       described_class.prefetched_policies
       described_class.prefetched_policies
-      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).once
     end
 
     it 'invalidate_cache! forces a fresh read' do
+      expect(described_class).to receive(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).twice.and_return(list_all_policies_output)
       described_class.prefetched_policies
       Puppet::Provider::Firewalld.invalidate_cache!(:policies)
       described_class.prefetched_policies
-      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).twice
     end
   end
 end

--- a/spec/unit/puppet/provider/firewalld_policy_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_policy_spec.rb
@@ -18,6 +18,9 @@ describe provider_class do
   let(:provider) { resource.provider }
 
   before do
+    # Every test starts with a clean transaction cache so that prefetched
+    # state from one example does not leak into another.
+    Puppet::Provider::Firewalld.invalidate_cache!
     allow(provider).to receive(:execute_firewall_cmd_policy).and_return(double(exitstatus: 0))
     allow(provider).to receive(:execute_firewall_cmd_policy).with(['--list-ingress-zones']).and_return(double(exitstatus: 0, chomp: ''))
     allow(provider).to receive(:execute_firewall_cmd_policy).with(['--list-egress-zones']).and_return(double(exitstatus: 0, chomp: ''))
@@ -70,6 +73,70 @@ describe provider_class do
 
         provider.description = :'Modified description'
       end
+    end
+  end
+
+  describe 'bulk prefetch' do
+    let(:list_all_policies_output) do
+      <<~OUTPUT
+        anytorestricted (active)
+          priority: -1
+          target: REJECT
+          ingress-zones: ANY
+          egress-zones: restricted
+          services:
+          ports:
+          protocols:
+          masquerade: no
+          forward-ports:
+          source-ports:
+          icmp-blocks: router-advertisement
+          rich rules:
+          description: Any to restricted
+          short: a2r
+
+        public2restricted (active)
+          priority: 100
+          target: default
+          ingress-zones: public
+          egress-zones: restricted
+          masquerade: yes
+          description: Public to restricted
+          short: p2r
+      OUTPUT
+    end
+
+    before do
+      allow(described_class).to receive(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).and_return(list_all_policies_output)
+    end
+
+    after do
+      Puppet::Provider::Firewalld.invalidate_cache!
+    end
+
+    it 'parses policy state into property_hash for each policy' do
+      instances = described_class.instances
+      p2r = instances.find { |i| i.name == 'public2restricted' }
+      expect(p2r).not_to be_nil
+      expect(p2r.get(:target)).to eq('default')
+      expect(p2r.get(:ingress_zones)).to eq(['public'])
+      expect(p2r.get(:egress_zones)).to eq(['restricted'])
+      expect(p2r.get(:priority)).to eq('100')
+      expect(p2r.get(:masquerade)).to eq(:true)
+      expect(p2r.get(:short)).to eq('p2r')
+    end
+
+    it 'serves a second prefetched_policies call from the cache' do
+      described_class.prefetched_policies
+      described_class.prefetched_policies
+      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).once
+    end
+
+    it 'invalidate_cache! forces a fresh read' do
+      described_class.prefetched_policies
+      Puppet::Provider::Firewalld.invalidate_cache!(:policies)
+      described_class.prefetched_policies
+      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-policies'], nil, nil).twice
     end
   end
 end

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -126,17 +126,17 @@ describe provider_class do
     end
 
     it 'serves a second prefetched_zones call from the cache' do
-      described_class.prefetched_zones
-      described_class.prefetched_zones
       # Only the very first invocation should shell out.
-      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-zones'], nil).once
+      expect(described_class).to receive(:execute_firewall_cmd).with(['--list-all-zones'], nil).once.and_return(list_all_zones_output)
+      described_class.prefetched_zones
+      described_class.prefetched_zones
     end
 
     it 'invalidate_cache! forces a fresh read' do
+      expect(described_class).to receive(:execute_firewall_cmd).with(['--list-all-zones'], nil).twice.and_return(list_all_zones_output)
       described_class.prefetched_zones
       Puppet::Provider::Firewalld.invalidate_cache!(:zones)
       described_class.prefetched_zones
-      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-zones'], nil).twice
     end
   end
 

--- a/spec/unit/puppet/provider/firewalld_zone_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_zone_spec.rb
@@ -17,6 +17,9 @@ describe provider_class do
   let(:provider) { resource.provider }
 
   before do
+    # Every test starts with a clean transaction cache so that prefetched
+    # state from one example does not leak into another.
+    Puppet::Provider::Firewalld.invalidate_cache!
     allow(provider).to receive(:execute_firewall_cmd).and_return(double(exitstatus: 0))
     allow(provider).to receive(:execute_firewall_cmd).with(['--list-interfaces']).and_return(double(exitstatus: 0, chomp: ''))
   end
@@ -63,6 +66,97 @@ describe provider_class do
 
         provider.description = :'Better description'
       end
+    end
+  end
+
+  describe 'bulk prefetch' do
+    let(:list_all_zones_output) do
+      <<~OUTPUT
+        public (active)
+          target: default
+          icmp-block-inversion: no
+          interfaces: eth0
+          sources:
+          services: ssh dhcpv6-client
+          ports:
+          protocols:
+          masquerade: no
+          forward-ports:
+          source-ports:
+          icmp-blocks:
+          rich rules:
+          description: Public zone
+          short: Public
+
+        internal (active)
+          target: ACCEPT
+          icmp-block-inversion: yes
+          interfaces: eth1 eth2
+          sources: 192.168.1.0/24
+          protocols: icmp
+          masquerade: yes
+          icmp-blocks: echo-request echo-reply
+          description: Internal zone
+          short: Internal
+      OUTPUT
+    end
+
+    before do
+      # Stub the bulk-prefetch shell-out to return our canned fixture.
+      # Using the class-level method matches what prefetch() actually
+      # invokes.
+      allow(described_class).to receive(:execute_firewall_cmd).with(['--list-all-zones'], nil).and_return(list_all_zones_output)
+    end
+
+    after do
+      Puppet::Provider::Firewalld.invalidate_cache!
+    end
+
+    it 'parses zone state into property_hash for each zone' do
+      instances = described_class.instances
+      internal = instances.find { |i| i.name == 'internal' }
+      expect(internal).not_to be_nil
+      expect(internal.get(:target)).to eq('ACCEPT')
+      expect(internal.get(:interfaces)).to eq(%w[eth1 eth2])
+      expect(internal.get(:sources)).to eq(['192.168.1.0/24'])
+      expect(internal.get(:masquerade)).to eq(:true)
+      expect(internal.get(:icmp_block_inversion)).to eq(:true)
+      expect(internal.get(:icmp_blocks)).to eq(%w[echo-reply echo-request])
+      expect(internal.get(:short)).to eq('Internal')
+    end
+
+    it 'serves a second prefetched_zones call from the cache' do
+      described_class.prefetched_zones
+      described_class.prefetched_zones
+      # Only the very first invocation should shell out.
+      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-zones'], nil).once
+    end
+
+    it 'invalidate_cache! forces a fresh read' do
+      described_class.prefetched_zones
+      Puppet::Provider::Firewalld.invalidate_cache!(:zones)
+      described_class.prefetched_zones
+      expect(described_class).to have_received(:execute_firewall_cmd).with(['--list-all-zones'], nil).twice
+    end
+  end
+
+  describe '.parse_list_all_output' do
+    it 'returns an empty Hash for empty input' do
+      expect(Puppet::Provider::Firewalld.parse_list_all_output('')).to eq({})
+      expect(Puppet::Provider::Firewalld.parse_list_all_output(nil)).to eq({})
+    end
+
+    it 'parses the zone name header with and without the (active) suffix' do
+      text = <<~OUTPUT
+        trusted
+          target: ACCEPT
+        public (active)
+          target: default
+      OUTPUT
+      result = Puppet::Provider::Firewalld.parse_list_all_output(text)
+      expect(result.keys).to contain_exactly('trusted', 'public')
+      expect(result['trusted']['target']).to eq('ACCEPT')
+      expect(result['public']['target']).to eq('default')
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This is an attempt to bunch together a bunch of the resource fetches into single commands.

In theory, this should query the system at agent run, cache the results, and re-use them where possible.  This should result in a speed up for complex firewalls with lots of zones and policies.

It will need extensive testing across multiple workflows.  It works on my site, which has a fairly simple deployment - cutting the runtime of firewalld resources by nearly 60%

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
